### PR TITLE
Remove console navigation item

### DIFF
--- a/www/deviceinfo.html
+++ b/www/deviceinfo.html
@@ -55,9 +55,6 @@
                   <a class="nav-link" href="/sms.html">SMS</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="/console">Console</a>
-                </li>
-                <li class="nav-item">
                   <a
                     class="nav-link active"
                     href="/deviceinfo.html"

--- a/www/index.html
+++ b/www/index.html
@@ -60,9 +60,6 @@
                   <a class="nav-link" href="/sms.html">SMS</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="/console">Console</a>
-                </li>
-                <li class="nav-item">
                   <a class="nav-link" href="/deviceinfo.html"
                     >Device Information</a
                   >

--- a/www/network.html
+++ b/www/network.html
@@ -63,9 +63,6 @@
                   <a class="nav-link" href="/sms.html">SMS</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="/console">Console</a>
-                </li>
-                <li class="nav-item">
                   <a class="nav-link" href="deviceinfo.html"
                     >Device Information</a
                   >

--- a/www/scanner.html
+++ b/www/scanner.html
@@ -65,9 +65,6 @@
                   <a class="nav-link" href="/sms.html">SMS</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="/console">Console</a>
-                </li>
-                <li class="nav-item">
                   <a class="nav-link" href="/deviceinfo.html"
                     >Device Information</a
                   >

--- a/www/settings.html
+++ b/www/settings.html
@@ -56,9 +56,6 @@
                   <a class="nav-link" href="/sms.html">SMS</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="/console">Console</a>
-                </li>
-                <li class="nav-item">
                   <a class="nav-link" href="/deviceinfo.html"
                     >Device Information</a
                   >

--- a/www/sms.html
+++ b/www/sms.html
@@ -45,9 +45,6 @@
                 <a class="nav-link active" aria-current="page" href="/sms.html">SMS</a>
               </li>
               <li class="nav-item">
-                <a class="nav-link" href="/console">Console</a>
-              </li>
-              <li class="nav-item">
                 <a class="nav-link" href="/deviceinfo.html">Device Information</a>
               </li>
             </ul>

--- a/www/watchcat.html
+++ b/www/watchcat.html
@@ -64,9 +64,6 @@
                   <a class="nav-link" href="/sms.html">SMS</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="/console">Console</a>
-                </li>
-                <li class="nav-item">
                   <a class="nav-link" href="/deviceinfo.html"
                     >Device Information</a
                   >

--- a/www/watchcat_backup.html
+++ b/www/watchcat_backup.html
@@ -67,9 +67,6 @@
                   <a class="nav-link" href="/sms.html">SMS</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link" href="/console">Console</a>
-                </li>
-                <li class="nav-item">
                   <a class="nav-link" href="/deviceinfo.html"
                     >Device Information</a
                   >


### PR DESCRIPTION
## Summary
- remove the Console navigation entry from all pages so the menu only links to working sections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69077936148483278103ab845dd0b0ce