### PR TITLE
Comment out Simple Scan navigation links

### DIFF
--- a/www/deviceinfo.html
+++ b/www/deviceinfo.html
@@ -45,9 +45,11 @@
                 <li class="nav-item">
                   <a class="nav-link" href="/network.html">Simple Network</a>
                 </li>
+                <!--
                 <li class="nav-item">
                   <a class="nav-link" href="/scanner.html">Simple Scan</a>
                 </li>
+                -->
                 <li class="nav-item">
                   <a class="nav-link" href="/settings.html">Simple Settings</a>
                 </li>

--- a/www/index.html
+++ b/www/index.html
@@ -50,9 +50,11 @@
                 <li class="nav-item">
                   <a class="nav-link" href="network.html">Simple Network</a>
                 </li>
-                <!--<li class="nav-item">
+                <!--
+                <li class="nav-item">
                   <a class="nav-link" href="/scanner.html">Simple Scan</a>
-                </li>-->
+                </li>
+                -->
                 <li class="nav-item">
                   <a class="nav-link" href="/settings.html">Simple Settings</a>
                 </li>

--- a/www/network.html
+++ b/www/network.html
@@ -53,9 +53,11 @@
                     >Simple Network</a
                   >
                 </li>
+                <!--
                 <li class="nav-item">
                   <a class="nav-link" href="/scanner.html">Simple Scan</a>
                 </li>
+                -->
                 <li class="nav-item">
                   <a class="nav-link" href="/settings.html">Simple Settings</a>
                 </li>

--- a/www/scanner.html
+++ b/www/scanner.html
@@ -50,6 +50,7 @@
                 <li class="nav-item">
                   <a class="nav-link" href="/network.html">Simple Network</a>
                 </li>
+                <!--
                 <li class="nav-item">
                   <a
                     class="nav-link active"
@@ -58,6 +59,7 @@
                     >Simple Scan</a
                   >
                 </li>
+                -->
                 <li class="nav-item">
                   <a class="nav-link" href="/settings.html">Simple Settings</a>
                 </li>

--- a/www/settings.html
+++ b/www/settings.html
@@ -41,9 +41,11 @@
                 <li class="nav-item">
                   <a class="nav-link" href="/network.html">Simple Network</a>
                 </li>
+                <!--
                 <li class="nav-item">
                   <a class="nav-link" href="/scanner.html">Simple Scan</a>
                 </li>
+                -->
                 <li class="nav-item">
                   <a
                     class="nav-link active"

--- a/www/sms.html
+++ b/www/sms.html
@@ -35,9 +35,11 @@
               <li class="nav-item">
                 <a class="nav-link" href="/network.html">Simple Network</a>
               </li>
+              <!--
               <li class="nav-item">
                 <a class="nav-link" href="/scanner.html">Simple Scan</a>
               </li>
+              -->
               <li class="nav-item">
                 <a class="nav-link" href="/settings.html">Simple Settings</a>
               </li>

--- a/www/watchcat.html
+++ b/www/watchcat.html
@@ -49,9 +49,11 @@
                 <li class="nav-item">
                   <a class="nav-link" href="/network.html">Simple Network</a>
                 </li>
+                <!--
                 <li class="nav-item">
                   <a class="nav-link" href="/scanner.html">Simple Scan</a>
                 </li>
+                -->
                 <li class="nav-item">
                   <a
                     class="nav-link active"


### PR DESCRIPTION
## Summary
- comment out the Simple Scan navigation entry across all navigation bars so the unusable menu item no longer appears

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_69077fd5d0f4832799528179d6affd3a