### PR TITLE
Rename Simple Settings tab to AT Terminal

### DIFF
--- a/www/deviceinfo.html
+++ b/www/deviceinfo.html
@@ -51,7 +51,7 @@
                 </li>
                 -->
                 <li class="nav-item">
-                  <a class="nav-link" href="/settings.html">Simple Settings</a>
+                  <a class="nav-link" href="/settings.html">AT Terminal</a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="/sms.html">SMS</a>

--- a/www/index.html
+++ b/www/index.html
@@ -56,7 +56,7 @@
                 </li>
                 -->
                 <li class="nav-item">
-                  <a class="nav-link" href="/settings.html">Simple Settings</a>
+                  <a class="nav-link" href="/settings.html">AT Terminal</a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="/sms.html">SMS</a>

--- a/www/network.html
+++ b/www/network.html
@@ -59,7 +59,7 @@
                 </li>
                 -->
                 <li class="nav-item">
-                  <a class="nav-link" href="/settings.html">Simple Settings</a>
+                  <a class="nav-link" href="/settings.html">AT Terminal</a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="/sms.html">SMS</a>

--- a/www/scanner.html
+++ b/www/scanner.html
@@ -61,7 +61,7 @@
                 </li>
                 -->
                 <li class="nav-item">
-                  <a class="nav-link" href="/settings.html">Simple Settings</a>
+                  <a class="nav-link" href="/settings.html">AT Terminal</a>
                 </li>
                 <li class="nav-item">
                   <a class="nav-link" href="/sms.html">SMS</a>

--- a/www/settings.html
+++ b/www/settings.html
@@ -51,7 +51,7 @@
                     class="nav-link active"
                     href="/settings.html"
                     aria-current="page"
-                    >Simple Settings</a
+                    >AT Terminal</a
                   >
                 </li>
                 <li class="nav-item">

--- a/www/sms.html
+++ b/www/sms.html
@@ -41,7 +41,7 @@
               </li>
               -->
               <li class="nav-item">
-                <a class="nav-link" href="/settings.html">Simple Settings</a>
+                <a class="nav-link" href="/settings.html">AT Terminal</a>
               </li>
               <li class="nav-item">
                 <a class="nav-link active" aria-current="page" href="/sms.html">SMS</a>

--- a/www/watchcat.html
+++ b/www/watchcat.html
@@ -59,7 +59,7 @@
                     class="nav-link active"
                     href="/settings.html"
                     aria-current="page"
-                    >Simple Settings</a
+                    >AT Terminal</a
                   >
                 </li>
                 <li class="nav-item">

--- a/www/watchcat_backup.html
+++ b/www/watchcat_backup.html
@@ -60,7 +60,7 @@
                     class="nav-link active"
                     href="/settings.html"
                     aria-current="page"
-                    >Simple Settings</a
+                    >AT Terminal</a
                   >
                 </li>
                 <li class="nav-item">


### PR DESCRIPTION
## Summary
- update navigation link labels across the UI from "Simple Settings" to "AT Terminal" to reflect the new tab name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690785f4a3ec8327bfc85c610298f255