### PR TITLE
Improve APN form validation and cleanup network settings UI

### DIFF
--- a/www/js/parse-settings.js
+++ b/www/js/parse-settings.js
@@ -1,112 +1,93 @@
 function parseCurrentSettings(rawdata) {
-  const data = rawdata;
-
-  const lines = data.split("\n");
+  const lines = rawdata.split("\n");
   console.log(lines);
 
-  // Remove QUIMSLOT and only take 1 or 2
-  this.sim = lines
-    .find(
-      (line) => line.includes("SIM1 ENABLE") || line.includes("SIM2 ENABLE")
-    )
-    .split(" ")[0]
-    // remove spaces
-    .replace(/\D/g, "");
-  // .replace(/\"/g, "");
-
-  try {
-    this.apn = lines
-      .find((line) => line.includes("+CGCONTRDP: 1"))
-      .split(",")[2]
-      .replace(/\"/g, "");
-  } catch (error) {
-    this.apn = "Failed fetching APN";
+  let sim = "-";
+  const simLine = lines.find(
+    (line) => line.includes("SIM1 ENABLE") || line.includes("SIM2 ENABLE")
+  );
+  if (simLine) {
+    sim = simLine.split(" ")[0].replace(/\D/g, "");
   }
 
-  this.cellLock4GStatus = lines
-    .find((line) => line.includes('LTE,Enable Bands :'))
-    .split(":")[1]
-    .replace(/\"/g, "");
+  let apn = "Failed fetching APN";
+  const apnLine = lines.find((line) => line.includes("+CGCONTRDP: 1"));
+  if (apnLine) {
+    apn = apnLine.split(",")[2].replace(/\"/g, "");
+  }
 
-  this.cellLock5GStatus = lines
-    .find((line) => line.includes('NR5G_SA,Enable Bands :'))
-    .split(":")[1]
-    .replace(/\"/g, "");
+  let apnIP = "-";
+  const apnIpLine = lines.find((line) => line.includes("+CGDCONT: 1"));
+  if (apnIpLine) {
+    apnIP = apnIpLine.split(",")[1].replace(/\"/g, "");
+  }
 
-  const prefNetworks = lines
-    .find((line) => line.includes('^SLMODE:'))
-    .split(":")[1]
-    .split(",")[1]
-    .replace(/\"/g, "").trim();
-  if( prefNetworks === "7"){
-	this.prefNetwork="AUTO"
-	}else if (prefNetworks === "2"){
-		this.prefNetwork="LTE Only"
-	}else if (prefNetworks === "6"){
-                this.prefNetwork="NR5G-NSA"
-        }else if (prefNetworks === "4"){
-                this.prefNetwork="NR5G-SA"
-        }
+  let cellLock4GStatus = "0";
+  const cellLock4GLine = lines.find((line) =>
+    line.includes("LTE,Enable Bands :")
+  );
+  if (cellLock4GLine) {
+    cellLock4GStatus = cellLock4GLine.split(":")[1].replace(/\"/g, "");
+  }
 
-/*
-  this.nrModeControlStatus = lines
-    .find((line) => line.includes('^SLMODE:'))
-    .split(":")[1]
-    .split(",")[1]
-    .replace(/\"/g, "").trim();
-*/
-  this.apnIP = lines
-    .find((line) => line.includes("+CGDCONT: 1"))
-    .split(",")[1]
-    .replace(/\"/g, "");
+  let cellLock5GStatus = "0";
+  const cellLock5GLine = lines.find((line) =>
+    line.includes("NR5G_SA,Enable Bands :")
+  );
+  if (cellLock5GLine) {
+    cellLock5GStatus = cellLock5GLine.split(":")[1].replace(/\"/g, "");
+  }
 
-  try {
-    const PCCbands = lines
-      .find((line) => line.includes('PCC info:'))
+  let prefNetwork = "-";
+  let prefNetworksValue = null;
+  const prefNetworkLine = lines.find((line) => line.includes("^SLMODE:"));
+  if (prefNetworkLine) {
+    prefNetworksValue = prefNetworkLine
       .split(":")[1]
-      .split("_")[1]
-      .replace(/\D/g, "");
-      //.replace(/\"/g, "");
-    
-    // Loop over all QCAINFO: "SCC" lines and get the bands
-    try {
-      const SCCbands = lines
-        .filter((line) => line.includes('SCC'))
-        .map((line) => line.split(":")[1].split("_")[1].replace(/\D/g, ""))
-        .join(", ");
-      this.bands = `${PCCbands}, ${SCCbands}`;
-    } catch (error) {
-      this.bands = PCCbands;
+      .split(",")[1]
+      .replace(/\"/g, "")
+      .trim();
+
+    if (prefNetworksValue === "7") {
+      prefNetwork = "AUTO";
+    } else if (prefNetworksValue === "2") {
+      prefNetwork = "LTE Only";
+    } else if (prefNetworksValue === "6") {
+      prefNetwork = "NR5G-NSA";
+    } else if (prefNetworksValue === "4") {
+      prefNetwork = "NR5G-SA";
     }
-    
-  } catch (error) {
-    this.bands = "Failed fetching bands";
   }
 
-  if (this.cellLock4GStatus == 1 && this.cellLock5GStatus == 1) {
-    this.cellLockStatus = "Locked to 4G and 5G";
-  } else if (this.cellLock4GStatus == 1) {
-    this.cellLockStatus = "Locked to 4G";
-  } else if (this.cellLock5GStatus == 1) {
-    this.cellLockStatus = "Locked to 5G";
-  } else {
-    this.cellLockStatus = "Not Locked";
+  let bands = "Failed fetching bands";
+  const pccLine = lines.find((line) => line.includes("PCC info:"));
+  if (pccLine) {
+    const pccBands = pccLine.split(":")[1].split("_")[1].replace(/\D/g, "");
+
+    const sccBands = lines
+      .filter((line) => line.includes("SCC"))
+      .map((line) => line.split(":")[1].split("_")[1].replace(/\D/g, ""))
+      .filter((value) => value.length > 0)
+      .join(", ");
+
+    bands = sccBands ? `${pccBands}, ${sccBands}` : pccBands;
   }
 
-  if (prefNetworks == "7") {
-    this.nrModeControlStatus = "Enable All";
-  } else if (prefNetworks == 6) {
-    this.nrModeControlStatus = "SA Disabled";
-  } else {
-    this.nrModeControlStatus = "NSA Disabled";
+  let cellLockStatus = "Not Locked";
+  if (cellLock4GStatus == 1 && cellLock5GStatus == 1) {
+    cellLockStatus = "Locked to 4G and 5G";
+  } else if (cellLock4GStatus == 1) {
+    cellLockStatus = "Locked to 4G";
+  } else if (cellLock5GStatus == 1) {
+    cellLockStatus = "Locked to 5G";
   }
+
   return {
-    sim: sim,
-    apn: apn,
-    apnIP: apnIP,
-    cellLockStatus: cellLockStatus,
-    prefNetwork: prefNetwork,
-    nrModeControl: nrModeControlStatus,
-    bands: bands,
+    sim,
+    apn,
+    apnIP,
+    cellLockStatus,
+    prefNetwork,
+    bands,
   };
 }

--- a/www/network.html
+++ b/www/network.html
@@ -155,6 +155,7 @@
                         id="APN"
                         x-model="newApn"
                         aria-describedby="APN"
+                        maxlength="63"
                         x-bind:placeholder="apn === '-' ? 'Fetching...' : apn"
                       />
                     </div>
@@ -170,13 +171,12 @@
                         aria-label="ipForAPN"
                       >
                         <option
+                          value=""
                           selected
                           x-text="apnIP === '-' ? 'Fetching...' : 'Current: ' + apnIP"
                         ></option>
                         <option value="1">IPv4 Only</option>
-                        <option value="2">IPv6 Only</option>
                         <option value="3">IPv4v6</option>
-                        <option value="4">P2P Protocol</option>
                       </select>
                     </div>
 
@@ -217,7 +217,7 @@
 
                   <div class="col">
                     <div class="mb-4">
-                      <label for="nrModeControl" class="form-label"
+                      <label for="prefNetworkMode" class="form-label"
                         >Select Preferred Network</label
                       >
                       <select
@@ -227,6 +227,7 @@
                         aria-label="prefNetworkMode"
                       >
                         <option
+                          value=""
                           selected
                           x-text="prefNetwork === '-' ? 'Fetching...' : 'Current: ' + prefNetwork"
                         ></option>
@@ -234,25 +235,6 @@
                         <option value="2">LTE Only</option>
                         <option value="6">NR5G-NSA</option>
                         <option value="4">NR5G-SA</option>
-                      </select>
-                    </div>
-                    <div class="mb-4">
-                      <label for="prefNetwork" class="form-label"
-                        >NR5G Mode Control</label
-                      >
-                      <select
-                        class="form-select"
-                        id="nrModeControl"
-                        x-model="nrModeControl"
-                        aria-label="nrModeControl"
-                      >
-                        <option
-                          selected
-                          x-text="nrModeControl === '-' ? 'Fetching...' : 'Current: ' + nrModeControl"
-                        ></option>
-                        <option value="0">Enable All</option>
-                        <option value="2">Disable NR5G-NSA</option>
-                        <option value="1">Disable NR5G-SA</option>
                       </select>
                     </div>
                   </div>
@@ -470,7 +452,6 @@
           newApn: null,
           prefNetwork: "-",
           prefNetworkMode: null,
-          nrModeControl: "-",
           cellNum: null,
           lte_bands: "",
           nsa_bands: "",
@@ -488,6 +469,37 @@
           rawdata: "",
           networkModeListenerAttached: false,
           providerBandsListenerAttached: false,
+          sanitizeApn(apn) {
+            if (typeof apn !== "string") {
+              return "";
+            }
+            return apn.trim();
+          },
+          isValidApn(apn) {
+            return /^[a-zA-Z0-9._-]{1,63}$/.test(apn);
+          },
+          mapApnTypeLabelToValue(label) {
+            const normalized = (label || "")
+              .toString()
+              .trim()
+              .toUpperCase();
+            const mapping = {
+              IPV4: "1",
+              IPV6: "2",
+              IPV4V6: "3",
+              PPP: "4",
+            };
+            return mapping[normalized] || null;
+          },
+          mapApnTypeValueToCommand(value) {
+            const mapping = {
+              "1": "IPV4",
+              "2": "IPV6",
+              "3": "IPV4V6",
+              "4": "PPP",
+            };
+            return mapping[value] || null;
+          },
 
           async getSupportedBands() {
             // Load the checkbox state from localStorage
@@ -756,7 +768,6 @@
               this.apnIP = settings.apnIP;
               this.cellLockStatus = settings.cellLockStatus;
               this.prefNetwork = settings.prefNetwork;
-              this.nrModeControl = settings.nrModeControl;
               this.bands = settings.bands;
             } catch (error) {
               this.lastErrorMessage = error.message || 'Errore nel parsing delle impostazioni correnti.';
@@ -856,70 +867,147 @@
             }, 1000);
           },
           async saveChanges() {
-            const newApn = this.newApn;
-            const newSim = this.newSim;
-            const prefNetworkMode = this.prefNetworkMode;
-            const nrModeControl = this.nrModeControl;
+            const commandParts = [];
+            const hasApnInput = typeof this.newApn === "string";
+            const sanitizedNewApn = hasApnInput
+              ? this.sanitizeApn(this.newApn)
+              : "";
 
-            let atAPN, atSIM, ATNetwork, ATNRMode, atcmd;
-            atAPN = "";
-            atSIM = "";
-            ATNetwork = "";
-            ATNRMode = "";
-            if (newApn !== null) {
-              if (this.newApnIP === "1") {
-                atAPN = `+CGDCONT=1,"IPV4","${newApn}";`;
-              } else if (this.newApnIP === "2") {
-                atAPN = `+CGDCONT=1,"IPV6","${newApn}";`;
-              } else if (this.newApnIP === "3") {
-                atAPN = `+CGDCONT=1,"IPV4V6","${newApn}";`;
-              } else if (this.newApnIP === "4") {
-                atAPN = `+CGDCONT=1,"PPP","${newApn}";`;
-              } else {
-                atAPN = `+CGDCONT=1,"IPV4V6","${newApn}";`;
+            if (hasApnInput) {
+              this.newApn = sanitizedNewApn;
+            }
+
+            const selectedApnTypeRaw = this.newApnIP;
+            const selectedApnType =
+              selectedApnTypeRaw === null || selectedApnTypeRaw === undefined || selectedApnTypeRaw === ""
+                ? null
+                : selectedApnTypeRaw;
+
+            const currentApnSanitized = this.sanitizeApn(this.apn);
+            const hasCurrentApn =
+              currentApnSanitized.length > 0 &&
+              this.apn !== "-" &&
+              this.apn !== "Failed fetching APN";
+
+            let targetApn = null;
+            let targetApnType = null;
+
+            if (hasApnInput) {
+              if (sanitizedNewApn.length === 0) {
+                alert("L'APN non può essere vuoto.");
+                return;
               }
-            }
-            if (newSim !== null) {
-              atSIM = `^SWITCH_SLOT=${newSim};`;
-            }
 
-            if (prefNetworkMode !== null) {
-              ATNetwork = `^SLMODE=1,${prefNetworkMode};`;
-            }
-            if (nrModeControl !== this.nrModeControl) {
-              ATNRMode = `+QNWPREFCFG="nr5g_disable_mode",${nrModeControl}`;
-            }
-
-            atcmd = `AT${atAPN}${atSIM}${ATNetwork}${ATNRMode}`;
-            // If there is double + (++), remove 1 + from the command
-            atcmd = atcmd.replace("+^", "^");
-            if (atcmd !== "AT+") {
-              this.showModal = true;
-
-              const result = await this.sendATcommand(atcmd);
-
-              if (!result.ok) {
-                this.showModal = false;
+              if (!this.isValidApn(sanitizedNewApn)) {
                 alert(
-                  this.lastErrorMessage ||
-                    "Impossibile salvare le modifiche di rete."
+                  "L'APN può contenere solo lettere, numeri, punti, trattini e underscore (max 63 caratteri)."
                 );
                 return;
               }
-              // Do a 15 second countdown
-              this.countdown = 15;
 
-              const interval = setInterval(() => {
-                this.countdown--;
-                if (this.countdown === 0) {
-                  clearInterval(interval);
-                  this.showModal = false;
-                  this.init();
-                }
-              }, 1000);
-            } else {
-              alert("No changes made");
+              targetApn = sanitizedNewApn;
             }
+
+            if (selectedApnType !== null) {
+              if (!["1", "3"].includes(selectedApnType)) {
+                alert("Seleziona un tipo PDP valido.");
+                return;
+              }
+
+              targetApnType = selectedApnType;
+            }
+
+            if (targetApn !== null && targetApnType === null) {
+              const currentType = this.mapApnTypeLabelToValue(this.apnIP);
+              targetApnType = currentType || "3";
+            }
+
+            if (targetApn === null && targetApnType !== null) {
+              if (!hasCurrentApn) {
+                alert(
+                  "Impossibile cambiare il tipo PDP perché l'APN corrente non è disponibile."
+                );
+                return;
+              }
+
+              if (!this.isValidApn(currentApnSanitized)) {
+                alert(
+                  "Impossibile cambiare il tipo PDP perché l'APN corrente non è valido."
+                );
+                return;
+              }
+
+              targetApn = currentApnSanitized;
+            }
+
+            if (targetApn !== null) {
+              if (targetApnType === null) {
+                const currentType = this.mapApnTypeLabelToValue(this.apnIP);
+
+                if (!currentType) {
+                  alert(
+                    "Impossibile determinare il tipo PDP corrente. Seleziona un nuovo valore."
+                  );
+                  return;
+                }
+
+                targetApnType = currentType;
+              }
+
+              const typeLabel = this.mapApnTypeValueToCommand(targetApnType);
+
+              if (!typeLabel) {
+                alert(
+                  "Impossibile costruire il comando APN a causa di un tipo PDP non valido."
+                );
+                return;
+              }
+
+              commandParts.push(`+CGDCONT=1,"${typeLabel}","${targetApn}";`);
+            }
+
+            if (this.newSim === "0" || this.newSim === "1") {
+              commandParts.push(`^SWITCH_SLOT=${this.newSim};`);
+            }
+
+            if (
+              this.prefNetworkMode !== null &&
+              this.prefNetworkMode !== undefined &&
+              this.prefNetworkMode !== ""
+            ) {
+              commandParts.push(`^SLMODE=1,${this.prefNetworkMode};`);
+            }
+
+            if (commandParts.length === 0) {
+              alert("No changes made");
+              return;
+            }
+
+            const atcmd = `AT${commandParts.join("")}`.replace("+^", "^");
+
+            this.showModal = true;
+
+            const result = await this.sendATcommand(atcmd);
+
+            if (!result.ok) {
+              this.showModal = false;
+              alert(
+                this.lastErrorMessage ||
+                  "Impossibile salvare le modifiche di rete."
+              );
+              return;
+            }
+            // Do a 15 second countdown
+            this.countdown = 15;
+
+            const interval = setInterval(() => {
+              this.countdown--;
+              if (this.countdown === 0) {
+                clearInterval(interval);
+                this.showModal = false;
+                this.init();
+              }
+            }, 1000);
           },
           async cellLockEnableLTE() {
             const cellNum = this.cellNum;


### PR DESCRIPTION
## Summary
- add client-side validation and sanitisation for APN inputs before composing AT commands
- remove unsupported PDP options and the unused NR5G Mode Control UI from the network page
- simplify the current settings parser to only expose the values still in use

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_69087b272c9c83279a0ef1f420b9d755