### PR TITLE
Map Italian network providers on home page

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -585,21 +585,6 @@
                   </table>
                 </div>
               </div>
-              <div class="card-footer">
-                <div class="card-text">
-                  <div class="row">
-                    <div class="col">
-                      <div>
-                        <p>Date Updated</p>
-                      </div>
-                    </div>
-
-                    <div class="col">
-                      <p x-text="lastUpdate"></p>
-                    </div>
-                  </div>
-                </div>
-              </div>
             </div>
           </div>
         </div>
@@ -743,6 +728,38 @@
 
     <script>
       function processAllInfos() {
+        const italianNetworkProviders = {
+          "22201": "TIM",
+          "22202": "Elsacom",
+          "22204": "Intermatica",
+          "22205": "Telespazio",
+          "22206": "Vodafone Italia",
+          "22207": "Kena Mobile",
+          "22208": "Fastweb",
+          "22210": "Vodafone Italia",
+          "22230": "RFI",
+          "22233": "PosteMobile",
+          "22234": "BT Italia",
+          "22235": "Lycamobile",
+          "22236": "Digi Mobil",
+          "22237": "Wind Tre",
+          "22238": "Linkem",
+          "22239": "SMS Italia",
+          "22241": "GO Internet",
+          "22243": "TIM",
+          "22247": "Fastweb",
+          "22248": "TIM",
+          "22249": "Vianova",
+          "22250": "Iliad",
+          "22253": "CoopVoce",
+          "22254": "Plintron",
+          "22256": "spusu",
+          "22277": "IPSE 2000",
+          "22288": "Wind Tre",
+          "22298": "Blu",
+          "22299": "Wind Tre",
+        };
+
         const defaultDataState = {
           atcmd: "",
           internetConnectionStatus: "Disconnected",
@@ -1279,23 +1296,31 @@
                     this.activeSim = "No SIM";
                   }
 
-                  // --- Network Provider ---
-                  let isp = lines
-                    .find((line) => line.includes("mcc:"))
-                    .replace(/\D/g, "")
-		  if (isp === "CHN-CMCC" || isp === "CMCC" || isp === "46000") {
-  			isp = "中国移动";
-		  } else if (isp === "CHN-UNICOM" || isp === "CUCC" || isp === "46001") {
-  			isp = "中国联通";
-		  } else if (isp === "CHN-CT" || isp === "CT" || isp === "46011") {
-  			isp = "中国电信";
-			}			
-                  this.networkProvider = isp;
+                  // --- Network Provider & MCCMNC ---
+                  const mccLine = lines.find((line) => line.includes("mcc:"));
+                  if (mccLine) {
+                    const mccMatch = mccLine.match(/mcc:\s*(\d+)/i);
+                    const mncMatch = mccLine.match(/mnc:\s*(\d+)/i);
+                    const mccmncCode =
+                      mccMatch && mncMatch
+                        ? `${mccMatch[1]}${mncMatch[1].padStart(2, "0")}`
+                        : mccLine.replace(/\D/g, "");
 
-                  // --- MCCMNC ---
-                  this.mccmnc = lines
-                    .find((line) => line.includes("mcc:"))
-                    .replace(/\D/g, "")
+                    const networkProviderMap = {
+                      ...italianNetworkProviders,
+                      "46000": "中国移动",
+                      "46001": "中国联通",
+                      "46011": "中国电信",
+                    };
+
+                    this.mccmnc = mccmncCode || "Unknown";
+                    this.networkProvider =
+                      networkProviderMap[mccmncCode] ||
+                      (mccmncCode ? mccmncCode : "Unknown");
+                  } else {
+                    this.mccmnc = "Unknown";
+                    this.networkProvider = "Unknown";
+                  }
                   // --- APN ---
                   // find this example value from lines "+CGCONTRDP: 1,0,\"internet.dito.ph\",\"100.65.141.236\",\"36.5.141.64.76.204.39.68.23.210.251.16.49.239.42.149\", \"254.128.0.0.0.0.0.0.0.0.0.0.0.0.0.1\",\"131.226.72.19\",\"131.226.73.19\"\r"
                   this.apn = lines


### PR DESCRIPTION
## Summary
- map MCC/MNC combinations to Italian carrier names on the dashboard
- fall back to known Chinese carrier mappings and default codes when unknown
- remove the signal information "Date Updated" footer section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908ae8425a48327a5f5dfb00c523f09