### PR TITLE
Clean up comments and translate GUI text to English

### DIFF
--- a/www/deviceinfo.html
+++ b/www/deviceinfo.html
@@ -4,12 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Simple Admin</title>
-    <!-- <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-      crossorigin="anonymous"
-    /> -->
     <!-- Import all the bootstrap css files from css folder -->
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
@@ -45,11 +39,6 @@
                 <li class="nav-item">
                   <a class="nav-link" href="/network.html">Simple Network</a>
                 </li>
-                <!--
-                <li class="nav-item">
-                  <a class="nav-link" href="/scanner.html">Simple Scan</a>
-                </li>
-                -->
                 <li class="nav-item">
                   <a class="nav-link" href="/settings.html">AT Terminal</a>
                 </li>
@@ -256,7 +245,7 @@
               if (!result.ok) {
                 const message = result.error
                   ? result.error.message
-                  : "Errore sconosciuto durante l'esecuzione del comando.";
+                  : "Unknown error while executing the command.";
                 this.handleError(message, result.data);
                 return;
               }
@@ -264,7 +253,7 @@
               this.atCommandResponse = result.data;
               this.showError = false;
             } catch (error) {
-              this.handleError(error.message || "Errore di rete durante l'esecuzione del comando.");
+              this.handleError(error.message || "Network error while executing the command.");
             } finally {
               this.isLoading = false;
             }
@@ -283,7 +272,7 @@
               if (!result.ok) {
                 const message = result.error
                   ? result.error.message
-                  : "Impossibile recuperare le informazioni del modem.";
+                  : "Unable to retrieve modem information.";
                 this.handleError(message, result.data);
                 return;
               }
@@ -292,7 +281,7 @@
               this.showError = false;
               this.parseFetchedData();
             } catch (error) {
-              this.handleError(error.message || "Errore di rete durante il recupero delle informazioni del modem.");
+              this.handleError(error.message || "Network error while retrieving modem information.");
             } finally {
               this.isLoading = false;
             }
@@ -308,7 +297,7 @@
 
           parseFetchedData() {
   if (!this.atCommandResponse) {
-    this.handleError("Risposta AT vuota dal modem.");
+    this.handleError("Empty AT response from the modem.");
     this.isLoading = false;
     return;
   }
@@ -366,7 +355,7 @@
         imsi = line;
         continue;
       }
-      // Fallback IMSI: 15 cifre, non inizia con 89 (ICCID), non è IMEI
+      // Fallback IMSI: 15 digits, does not start with 89 (ICCID), and is not an IMEI
       if ((!imsi || imsi === "-") && /^\d{15}$/.test(line) && !line.startsWith("89") && line !== imei) {
         imsi = line;
         continue;
@@ -374,7 +363,7 @@
 
       // IMEI
       if (ctx?.startsWith("AT+CGSN")) {
-        // Può essere solo cifre oppure "+CGSN: 86..."
+        // It can be digits only or the string "+CGSN: 86..."
         const m = line.match(/(\d{15,17})/);
         if (m) { imei = m[1].slice(0, 15); }
         continue;
@@ -425,8 +414,8 @@
     this.simpleAdminVersion = "T99-BETA011";
     this.showError = false;
   } catch (error) {
-    console.error("Errore nel parsing:", error);
-    this.handleError("Impossibile interpretare la risposta del modem.", this.atCommandResponse);
+    console.error("Parsing error:", error);
+    this.handleError("Unable to interpret the modem response.", this.atCommandResponse);
   } finally {
     this.isLoading = false;
   }
@@ -435,7 +424,7 @@
           updateIMEI() {
 	    let extended = "80A" + this.newImei;
 
-    	    // 2. 两位交换顺序
+    	    // 2. Swap each pair of characters
             let swapped = "";
             for (let i = 0; i < extended.length; i += 2) {
             let pair = extended.substr(i, 2);
@@ -446,7 +435,7 @@
                    }
             }
 		
-    	    // 3. 每两位加逗号，并转小写
+    	    // 3. Insert commas every two characters and convert to lowercase
             let formatted = swapped.match(/.{1,2}/g).join(",").toLowerCase();
 	    //console.log(formatted)
             this.atcmd = `at^nv=550,"0"';^nv=550,9,"${formatted}"`;

--- a/www/index.html
+++ b/www/index.html
@@ -4,12 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Simple Admin</title>
-    <!-- <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-      crossorigin="anonymous"
-    /> -->
     <!-- Import all the bootstrap css files from css folder -->
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
@@ -50,11 +44,6 @@
                 <li class="nav-item">
                   <a class="nav-link" href="network.html">Simple Network</a>
                 </li>
-                <!--
-                <li class="nav-item">
-                  <a class="nav-link" href="/scanner.html">Simple Scan</a>
-                </li>
-                -->
                 <li class="nav-item">
                   <a class="nav-link" href="/settings.html">AT Terminal</a>
                 </li>
@@ -252,12 +241,6 @@
                         <th scope="row">Assessment</th>
                         <td x-text="signalAssessment"></td>
                       </tr>
-                     <!-- <tr>
-                        <th scope="row">Traffic Stats</th>
-                        <td
-                          x-text="downloadStat + ' DL / ' + uploadStat + ' UL'"
-                        ></td>
-                      </tr> -->
                       <tr>
                         <th scope="row">Network Mode</th>
                         <td x-text="networkMode"></td>
@@ -299,11 +282,6 @@
                         <th scope="row">TAC<sup>4G/5G</sup></th>
                         <td x-text="tac"></td>
                       </tr>
-                      <!-- <tr x-show="rssi != '-'">
-                        <th scope="row">RSSI<sup>4G</sup></th>
-                        <td x-show="rssi != '-'" x-text="rssi"></td>
-                        <td x-show="rssi == '-'" class="fst-italic">None</td>
-                      </tr> -->
                       <tr x-show="rsrqLTE != '-'">
                         <th scope="row">SS_RSRQ<sup>4G</sup></th>
                         <td
@@ -1408,9 +1386,9 @@
 
                     const networkProviderMap = {
                       ...italianNetworkProviders,
-                      "46000": "中国移动",
-                      "46001": "中国联通",
-                      "46011": "中国电信",
+                      "46000": "China Mobile",
+                      "46001": "China Unicom",
+                      "46011": "China Telecom",
                     };
 
                     this.mccmnc = mccmncCode || "Unknown";
@@ -2074,12 +2052,14 @@
                   }
                 this.lastUpdate = new Date().toLocaleString();
               } catch (parseError) {
-                console.error("Errore durante il parsing della risposta AT", parseError);
-                this.applyFallback('Errore nel parsing della risposta AT.');
+                console.error("Error while parsing the AT response", parseError);
+                this.applyFallback("Failed to parse the AT response.");
               }
             } catch (error) {
-              console.error("Errore durante l'esecuzione del comando AT", error);
-              this.applyFallback(error.message || 'Errore sconosciuto durante la richiesta AT.');
+              console.error("Error while executing the AT command", error);
+              this.applyFallback(
+                error.message || "Unknown error occurred during the AT request."
+              );
             }
           },
 

--- a/www/js/atcommand-utils.js
+++ b/www/js/atcommand-utils.js
@@ -47,7 +47,7 @@
     const sanitized = sanitize(atcmd);
 
     if (!sanitized) {
-      return createResult(false, "", new Error("Comando AT vuoto o non valido."), {
+      return createResult(false, "", new Error("Empty or invalid AT command."), {
         busy: false,
         attempts: 0,
       });
@@ -86,14 +86,14 @@
           lastData = text;
 
           if (!text.trim()) {
-            lastError = new Error("Risposta vuota dal modem.");
+            lastError = new Error("Empty response from the modem.");
           } else if (isBusyResponse(text)) {
             busy = true;
-            lastError = new Error("Il modem è occupato, riprovare più tardi.");
+            lastError = new Error("The modem is busy. Try again later.");
           } else {
             const hasErrorToken = text.includes("ERROR");
 
-            return createResult(!hasErrorToken, text, hasErrorToken ? new Error("Il modem ha restituito ERROR.") : null, {
+            return createResult(!hasErrorToken, text, hasErrorToken ? new Error("The modem returned ERROR.") : null, {
               busy: false,
               attempts: attempt,
             });
@@ -101,7 +101,7 @@
         }
       } catch (error) {
         if (error.name === "AbortError") {
-          lastError = new Error("Timeout della richiesta AT.");
+          lastError = new Error("AT request timed out.");
         } else {
           lastError = error;
         }

--- a/www/js/generate-freq-box.js
+++ b/www/js/generate-freq-box.js
@@ -31,7 +31,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
   if (!freqNumbersContainer || !cellNumInput) {
     console.warn(
-      "Impossibile inizializzare i campi delle frequenze: elementi richiesti mancanti."
+      "Unable to initialize frequency fields: required elements are missing."
     );
     return;
   }

--- a/www/js/populate-checkbox.js
+++ b/www/js/populate-checkbox.js
@@ -12,7 +12,7 @@ function populateCheckboxes(
 
   if (!checkboxesForm || !networkModeElement) {
     console.warn(
-      "Impossibile popolare le checkbox: elementi richiesti mancanti."
+      "Unable to populate the checkboxes: required elements are missing."
     );
     return;
   }

--- a/www/network.html
+++ b/www/network.html
@@ -4,12 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Simple Admin</title>
-    <!-- <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-      crossorigin="anonymous"
-    /> -->
     <!-- Import all the bootstrap css files from css folder -->
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
@@ -53,11 +47,6 @@
                     >Simple Network</a
                   >
                 </li>
-                <!--
-                <li class="nav-item">
-                  <a class="nav-link" href="/scanner.html">Simple Scan</a>
-                </li>
-                -->
                 <li class="nav-item">
                   <a class="nav-link" href="/settings.html">AT Terminal</a>
                 </li>
@@ -102,9 +91,7 @@
                 <h5 class="card-subtitle" x-show="isGettingBands === true">
                   Fetching supported bands...
                 </h5>
-                <form id="checkboxForm" x-show="isGettingBands === false">
-                  <!-- Checkboxes will be populated here -->
-                </form>
+                <form id="checkboxForm" x-show="isGettingBands === false"></form>
               </div>
               <div class="card-footer">
                 <div class="d-flex align-items-center">
@@ -273,7 +260,6 @@
                 </select>
 
                 <div class="my-4">
-                  <!-- For LTE -->
                   <div id="lteElementsCell" x-show="networkModeCell == 'LTE'">
                     <div class="input-group mb-3">
                       <span class="input-group-text" id="basic-addon1"
@@ -292,11 +278,8 @@
                     </div>
                   </div>
 
-                  <div id="freqNumbersContainer">
-                    <!-- Generate EARFCN and PCI here -->
-                  </div>
+                  <div id="freqNumbersContainer"></div>
 
-                  <!-- For SA -->
                   <div
                     id="saElementsCell"
                     x-show="networkModeCell == 'NR5G-SA'"
@@ -411,8 +394,6 @@
       </div>
     </main>
 
-    <!-- Import Band Locking GUI JS -->
-    <!-- <script src="js/band-locking.js"></script> -->
     <script src="js/generate-freq-box.js"></script>
     <script src="js/populate-checkbox.js"></script>
     <script src="js/parse-settings.js"></script>
@@ -477,7 +458,7 @@
                 ok: false,
                 message:
                   this.lastErrorMessage ||
-                  "Impossibile leggere i profili APN correnti.",
+                  "Unable to read current APN profiles.",
               };
             }
 
@@ -515,7 +496,7 @@
                   ok: false,
                   message:
                     this.lastErrorMessage ||
-                    `Impossibile rimuovere il profilo APN ${ctx.cid}.`,
+                    `Unable to remove APN profile ${ctx.cid}.`,
                 };
               }
             }
@@ -572,10 +553,10 @@
 
               if (!result.ok || !result.data) {
                 console.warn(
-                  "Impossibile recuperare le bande supportate:",
+                  "Unable to fetch supported bands:",
                   this.lastErrorMessage
                 );
-                this.bands = "Bande non disponibili";
+                this.bands = "Bands not available";
                 return;
               }
 
@@ -642,7 +623,7 @@
 
             if (!result.ok || !result.data) {
               console.warn(
-                "Impossibile recuperare le bande bloccate:",
+                "Unable to retrieve locked bands:",
                 this.lastErrorMessage
               );
               this.locked_lte_bands = "";
@@ -728,7 +709,7 @@
                 }
               } catch (error) {
                 console.error(
-                  "Errore durante il popolamento delle bande supportate:",
+                  "Error while populating supported bands:",
                   error
                 );
               }
@@ -763,7 +744,7 @@
               const dropdown = document.getElementById("networkModeBand");
 
               if (!dropdown) {
-                console.warn("Dropdown delle modalità di rete non trovato.");
+                console.warn("Network mode dropdown not found.");
                 return;
               }
 
@@ -782,7 +763,7 @@
               const providerBands = document.getElementById("providerBands");
 
               if (!providerBands) {
-                console.warn("Checkbox per le bande del provider non trovata.");
+                console.warn("Provider bands checkbox not found.");
                 return;
               }
 
@@ -805,7 +786,7 @@
             const result = await this.sendATcommand(atcmd);
 
             if (!result.ok || !result.data) {
-              console.warn("Impossibile recuperare le impostazioni correnti:", this.lastErrorMessage);
+              console.warn("Unable to fetch current settings:", this.lastErrorMessage);
               return;
             }
 
@@ -823,8 +804,8 @@
               this.prefNetwork = settings.prefNetwork;
               this.bands = settings.bands;
             } catch (error) {
-              this.lastErrorMessage = error.message || 'Errore nel parsing delle impostazioni correnti.';
-              console.error('Errore durante il parsing delle impostazioni correnti:', error);
+              this.lastErrorMessage = error.message || 'Error while parsing the current settings.';
+              console.error('Error while parsing the current settings:', error);
             }
           },
 
@@ -873,7 +854,7 @@
                 this.showModal = false;
                 alert(
                   this.lastErrorMessage ||
-                    "Impossibile bloccare le bande selezionate. Riprova."
+                    "Unable to lock the selected bands. Please try again."
                 );
                 return;
               }
@@ -902,7 +883,7 @@
               this.showModal = false;
               alert(
                 this.lastErrorMessage ||
-                  "Impossibile ripristinare il blocco delle bande."
+                  "Unable to restore the band lock."
               );
               return;
             }
@@ -949,13 +930,13 @@
 
             if (hasApnInput) {
               if (sanitizedNewApn.length === 0) {
-                alert("L'APN non può essere vuoto.");
+                alert("APN cannot be empty.");
                 return;
               }
 
               if (!this.isValidApn(sanitizedNewApn)) {
                 alert(
-                  "L'APN può contenere solo lettere, numeri, punti, trattini e underscore (max 63 caratteri)."
+                  "The APN can include only letters, numbers, periods, hyphens, and underscores (max 63 characters)."
                 );
                 return;
               }
@@ -980,14 +961,14 @@
             if (targetApn === null && targetApnType !== null) {
               if (!hasCurrentApn) {
                 alert(
-                  "Impossibile cambiare il tipo PDP perché l'APN corrente non è disponibile."
+                  "Unable to change the PDP type because the current APN is unavailable."
                 );
                 return;
               }
 
               if (!this.isValidApn(currentApnSanitized)) {
                 alert(
-                  "Impossibile cambiare il tipo PDP perché l'APN corrente non è valido."
+                  "Unable to change the PDP type because the current APN is invalid."
                 );
                 return;
               }
@@ -1001,7 +982,7 @@
 
                 if (!currentType) {
                   alert(
-                    "Impossibile determinare il tipo PDP corrente. Seleziona un nuovo valore."
+                    "Unable to determine the current PDP type. Please select a new value."
                   );
                   return;
                 }
@@ -1013,21 +994,21 @@
 
               if (!typeLabel) {
                 alert(
-                  "Impossibile costruire il comando APN a causa di un tipo PDP non valido."
+                  "Unable to build the APN command because the PDP type is invalid."
                 );
                 return;
               }
 
               commandsToRun.push({
                 command: `AT+CGDCONT=1,"${typeLabel}","${targetApn}"`,
-                errorMessage: "Impossibile configurare l'APN.",
+                errorMessage: "Unable to configure the APN.",
               });
             }
 
             if (this.newSim === "0" || this.newSim === "1") {
               commandsToRun.push({
                 command: `AT^SWITCH_SLOT=${this.newSim}`,
-                errorMessage: "Impossibile cambiare SIM.",
+                errorMessage: "Unable to switch SIM.",
               });
             }
 
@@ -1038,7 +1019,7 @@
             ) {
               commandsToRun.push({
                 command: `AT^SLMODE=1,${this.prefNetworkMode}`,
-                errorMessage: "Impossibile salvare la rete preferita.",
+                errorMessage: "Unable to save the preferred network.",
               });
             }
 
@@ -1060,7 +1041,7 @@
                 this.showModal = false;
                 alert(
                   cleanupResult.message ||
-                    "Impossibile preparare i profili APN."
+                    "Unable to prepare the APN profiles."
                 );
                 return;
               }
@@ -1074,7 +1055,7 @@
                 alert(
                   this.lastErrorMessage ||
                     step.errorMessage ||
-                    "Impossibile eseguire il comando richiesto."
+                    "Unable to execute the requested command."
                 );
                 return;
               }
@@ -1087,7 +1068,7 @@
                 this.showModal = false;
                 alert(
                   this.lastErrorMessage ||
-                    "Errore nello spegnimento della baseband."
+                    "Error while shutting down the baseband."
                 );
                 return;
               }
@@ -1098,7 +1079,7 @@
                 this.showModal = false;
                 alert(
                   this.lastErrorMessage ||
-                    "Errore nella riaccensione della baseband."
+                    "Error while restarting the baseband."
                 );
                 return;
               }
@@ -1164,7 +1145,7 @@
               this.showModal = false;
               alert(
                 this.lastErrorMessage ||
-                  "Impossibile applicare il blocco LTE."
+                  "Unable to apply the LTE lock."
               );
               return;
             }
@@ -1206,7 +1187,7 @@
               this.showModal = false;
               alert(
                 this.lastErrorMessage ||
-                  "Impossibile applicare il blocco NR5G."
+                  "Unable to apply the NR5G lock."
               );
               return;
             }
@@ -1232,7 +1213,7 @@
               this.showModal = false;
               alert(
                 this.lastErrorMessage ||
-                  "Impossibile disattivare il blocco LTE."
+                  "Unable to remove the LTE lock."
               );
               return;
             }
@@ -1258,7 +1239,7 @@
               this.showModal = false;
               alert(
                 this.lastErrorMessage ||
-                  "Impossibile disattivare il blocco NR5G."
+                  "Unable to remove the NR5G lock."
               );
               return;
             }
@@ -1274,7 +1255,7 @@
           },
           async sendATcommand(atcmd) {
             if (!atcmd || typeof atcmd !== "string") {
-              const error = new Error("Comando AT non valido.");
+              const error = new Error("Invalid AT command.");
               this.lastErrorMessage = error.message;
               console.error("AT command validation error:", error);
               return { ok: false, data: "", error };
@@ -1289,7 +1270,7 @@
               if (!result.ok) {
                 const message = result.error
                   ? result.error.message
-                  : "Errore sconosciuto durante l'esecuzione del comando.";
+                  : "Unknown error while executing the command.";
                 this.lastErrorMessage = message;
                 console.warn("AT command failed:", message);
               } else {
@@ -1298,7 +1279,7 @@
 
               return result;
             } catch (error) {
-              const message = error.message || "Errore imprevisto durante il comando AT.";
+              const message = error.message || "Unexpected error during the AT command.";
               this.lastErrorMessage = message;
               console.error("AT command execution error:", error);
               return { ok: false, data: "", error };
@@ -1330,7 +1311,7 @@
         const uncheckButton = document.getElementById("uncheckAll");
 
         if (!uncheckButton) {
-          console.warn('Pulsante "Uncheck All" non trovato.');
+          console.warn('"Uncheck All" button not found.');
           return;
         }
 

--- a/www/scanner.html
+++ b/www/scanner.html
@@ -4,12 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Simple Admin</title>
-    <!-- <link
-			href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-			rel="stylesheet"
-			integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-			crossorigin="anonymous"
-		/> -->
     <!-- Import all the bootstrap css files from css folder -->
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
@@ -50,16 +44,6 @@
                 <li class="nav-item">
                   <a class="nav-link" href="/network.html">Simple Network</a>
                 </li>
-                <!--
-                <li class="nav-item">
-                  <a
-                    class="nav-link active"
-                    href="/scanner.html"
-                    aria-current="page"
-                    >Simple Scan</a
-                  >
-                </li>
-                -->
                 <li class="nav-item">
                   <a class="nav-link" href="/settings.html">AT Terminal</a>
                 </li>
@@ -81,7 +65,6 @@
           </div>
         </nav>
 
-        <!-- <div class="row mt-3 mb-4">
           <div class="col">
             <div class="card">
               <div class="card-header">Live Signal</div>
@@ -116,7 +99,6 @@
                       </tr>
                     </thead>
                     <tbody id="cellScanTableBody">
-                      <!-- CELL ROWS HERE -->
                     </tbody>
                   </table>
                   <div>
@@ -184,7 +166,6 @@
                     </tr>
                   </thead>
                   <tbody id="neighbourCellTableBody">
-                    <!-- NEIGHBOUR CELL ROWS HERE -->
                   </tbody>
                 </table>
                 <div>
@@ -1940,15 +1921,15 @@
                 this.errorMessage = "";
                 this.resultDoneCell = true;
               } catch (parseError) {
-                console.error("Errore nel parsing della scansione celle:", parseError);
+                console.error("Error parsing cell scan:", parseError);
                 this.handleScanError(
-                  "Errore nel parsing della scansione delle celle.",
+                  "Error parsing cell scan.",
                   "cell"
                 );
               }
             } catch (error) {
               this.handleScanError(
-                error.message || "Errore imprevisto durante la scansione delle celle.",
+                error.message || "Unexpected error while scanning cells.",
                 "cell"
               );
             } finally {
@@ -2159,18 +2140,18 @@
                 this.resultDoneNeighbourCell = true;
               } catch (parseError) {
                 console.error(
-                  "Errore nel parsing della scansione delle celle vicine:",
+                  "Error parsing neighbor cell scan:",
                   parseError
                 );
                 this.handleScanError(
-                  "Errore nel parsing della scansione delle celle vicine.",
+                  "Error parsing neighbor cell scan.",
                   "neighbour"
                 );
               }
             } catch (error) {
               this.handleScanError(
                 error.message ||
-                  "Errore imprevisto durante la scansione delle celle vicine.",
+                  "Unexpected error while scanning neighbor cells.",
                 "neighbour"
               );
             } finally {

--- a/www/settings.html
+++ b/www/settings.html
@@ -41,11 +41,6 @@
                 <li class="nav-item">
                   <a class="nav-link" href="/network.html">Simple Network</a>
                 </li>
-                <!--
-                <li class="nav-item">
-                  <a class="nav-link" href="/scanner.html">Simple Scan</a>
-                </li>
-                -->
                 <li class="nav-item">
                   <a
                     class="nav-link active"
@@ -79,7 +74,6 @@
               <div class="card-body">
                 <div class="card-text">
                   <div class="form-floating mb-4">
-                    <!-- At commands output here -->
                     <textarea
                       class="form-control"
                       placeholder="ATI"
@@ -106,7 +100,7 @@
                         @keydown.enter="sendATCommand()"
                       />
                       <div id="atCommandInputHelper" class="form-text">
-                        Seperate multiple commands with comma (,).
+                        Separate multiple commands with comma (,).
                       </div>
                     </div>
                     <div
@@ -170,92 +164,7 @@
                             </button>
                           </td>
                         </tr>
-                        <!--<tr>
-                          <th scope="row">IP Passthrough</th>
-                          <td>
-                            <select
-                              class="form-select"
-                              id="ipPassModeSelect"
-                              x-model="ipPassMode"
-                            >
-                              <option selected>Passthrough Mode</option>
-                              <option value="ETH">ETH</option>
-                              <option value="USB">USB (ECM/RNDIS)</option>
-                            </select>
-                          </td>
-                          <td>
-                            <button
-                              type="submit"
-                              class="btn btn-primary"
-                              @click="ipPassThroughEnable()"
-                              x-show="ipPassStatus === false"
-                              :disabled="isLoading"
-                            >
-                              Enable
-                            </button>
-                            <button
-                              type="submit"
-                              class="btn btn-danger"
-                              @click="ipPassThroughDisable()"
-                              x-show="ipPassStatus === true"
-                              :disabled="isLoading"
-                            >
-                              Disable
-                            </button>
-                          </td>
-                        </tr>
-                        <tr>
-                          <th scope="row">USB Modem Protocol</th>
-                          <td>
-                            <select
-                              class="form-select"
-                              id="usbNetModeSelect"
-                              x-model="usbNetMode"
-                            >
-                              <option
-                                selected
-                                x-text="currentUsbNetMode"
-                              ></option>
-                              <option value="RMNET">RMNET</option>
-                              <option value="ECM">ECM (Recommended)</option>
-                              <option value="MBIM">MBIM</option>
-                              <option value="RNDIS">RNDIS</option>
-                            </select>
-                          </td>
-                          <td>
-                            <button
-                              type="submit"
-                              class="btn btn-primary"
-                              @click="usbNetModeChanger()"
-                              :disabled="isLoading"
-                            >
-                              Change
-                            </button>
-                          </td>
-                        </tr>
-                        <tr>
-                          <th scope="row">Onboard DNS Proxy</th>
-                          <td>
-                            <button
-                              type="submit"
-                              class="btn btn-primary"
-                              @click="onBoardDNSProxyEnable()"
-                              x-show="DNSProxyStatus === false"
-                              :disabled="isLoading"
-                            >
-                              Enable
-                            </button>
-                            <button
-                              type="submit"
-                              class="btn btn-danger"
-                              @click="onBoardDNSProxyDisable()"
-                              x-show="DNSProxyStatus === true"
-                              :disabled="isLoading"
-                            >
-                              Disable
-                            </button>
-                          </td>
-                        </tr>-->
+
                       </tbody>
                     </table>
                   </div>
@@ -316,12 +225,6 @@
                     </button>
                   </div>
                 </div>
-                <!-- <div class="card-text">
-                  <div class="d-flex flex-row gap-4 w-full">
-                    <p><a class="link-info link-opacity-50-hover link-offset-2" href="/scanner.html">Go to Cell Scanner</a></p>
-                    <p><a class="link-info link-opacity-50-hover link-offset-2" href="/watchcat.html">Go to WatchCat</a></p>
-                  </div>
-                </div> -->
               </div>
             </div>
           </div>
@@ -441,7 +344,7 @@
               if (!result.ok) {
                 const message = result.error
                   ? result.error.message
-                  : "Errore sconosciuto durante l'esecuzione del comando.";
+                  : "Unknown error while executing the command.";
                 this.handleAtError(message, result.data);
                 return;
               }
@@ -451,7 +354,7 @@
               this.isClean = false;
             } catch (error) {
               this.handleAtError(
-                error.message || "Errore di rete durante l'esecuzione del comando."
+                error.message || "Network error while executing the command."
               );
             } finally {
               this.isLoading = false;
@@ -474,7 +377,7 @@
               this.isClean = false;
             } catch (error) {
               this.handleAtError(
-                error.message || "Errore di rete durante l'esecuzione del comando personalizzato."
+                error.message || "Network error while executing the custom command."
               );
             } finally {
               this.isLoading = false;
@@ -591,9 +494,9 @@
               if (!result.ok || !result.data) {
                 const message = result.error
                   ? result.error.message
-                  : 'Impossibile recuperare le impostazioni correnti.';
+                  : 'Unable to fetch current settings.';
                 this.errorMessage = message;
-                console.warn('Errore fetchCurrentSettings:', message);
+                console.warn('fetchCurrentSettings error:', message);
                 return;
               }
 
@@ -631,8 +534,8 @@
 
               this.atcmd = '';
             } catch (error) {
-              this.errorMessage = error.message || 'Errore di rete durante il recupero delle impostazioni correnti.';
-              console.error('Errore in fetchCurrentSettings:', error);
+              this.errorMessage = error.message || 'Network error while retrieving current settings.';
+              console.error('Error in fetchCurrentSettings:', error);
             }
           },
 

--- a/www/sms.html
+++ b/www/sms.html
@@ -5,16 +5,16 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Simple Admin</title>
-  <!-- 导入自定义和Bootstrap样式 -->
+  
   <link rel="stylesheet" href="css/styles.css" />
   <link rel="stylesheet" href="css/bootstrap.min.css" />
-  <!-- 网站图标 -->
+  
   <link rel="icon" href="favicon.ico" />
-  <!-- 导入Bootstrap和Alpine.js脚本 -->
+  
   <script src="js/bootstrap.bundle.min.js"></script>
   <script src="js/alpinejs.min.js" defer></script>
 
-  <!-- Contributed By: snjzb -->
+  
 </head>
 
 <body>
@@ -24,7 +24,7 @@
         <div class="container-fluid">
           <a class="navbar-brand" href="/"><span class="mb-0 h4">Simple Admin</span></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarText"
-            aria-controls="navbarText" aria-expanded="false" aria-label="切换导航">
+            aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
           </button>
           <div class="collapse navbar-collapse" id="navbarText">
@@ -35,11 +35,7 @@
               <li class="nav-item">
                 <a class="nav-link" href="/network.html">Simple Network</a>
               </li>
-              <!--
-              <li class="nav-item">
-                <a class="nav-link" href="/scanner.html">Simple Scan</a>
-              </li>
-              -->
+              
               <li class="nav-item">
                 <a class="nav-link" href="/settings.html">AT Terminal</a>
               </li>
@@ -75,15 +71,15 @@
                     </div>
                     <table class="table table-hover border-success" x-show="!isLoading">
                       <tbody>
-                        <!-- 没有消息时显示 -->
-                        <!-- Display when there are no messages -->
+                        
+                        
                         <template x-if="messages.length === 0 && !isLoading">
                           <div>
                             <p>Inbox is Empty</p>
                           </div>
                         </template>
-                        <!-- 循环显示短信消息 -->
-                        <!-- "Loop display SMS messages" -->
+                        
+                        
                         <template x-for="(message, index) in messages" :key="index">
                           <tr>
                             <td>
@@ -111,8 +107,8 @@
                 </div>
               </div>
             </div>
-            <!-- 添加判断，只有当messages数组有内容时才显示全选复选框及其区域 -->
-            <!-- Add a judgment, only when the messages array has content will the select all checkbox and its area be displayed" -->
+            
+            
             <div class="card-body border-top" x-show="messages.length > 0">
               <div class="form-check">
                 <input id="selectAllCheckbox" class="form-check-input" type="checkbox" @change="toggleAll($event)" />
@@ -121,13 +117,13 @@
             </div>
             <div class="card-footer">
               <div class="d-grid gap-2 d-md-flex justify-content-md-start">
-                <!-- 刷新按钮 -->
-                <!-- Refresh button -->
+                
+                
                 <button class="btn btn-success" type="button" @click="init()">
                   Refresh
                 </button>
-                <!-- 删除选中短信按钮 -->
-                <!-- Delete selected SMS button -->
+                
+                
                 <button class="btn btn-danger" type="button" @click="deleteSelectedSMS()">
                   Delete Selected SMS
                 </button>
@@ -174,11 +170,11 @@
         selectedMessages: [],
         phoneNumber: '',
         messageToSend: '',
-        messageIndices: [], // 确保初始化messageIndices数组
+        messageIndices: [], // Ensure the messageIndices array is initialized
         showError: false,
         errorMessage: "",
 
-        // 清除现有数据
+        // Clear existing data
         clearData() {
           this.messages = [];
           this.senders = [];
@@ -200,7 +196,7 @@
           console.error("SMS error:", message);
         },
 
-        // 请求获取短信
+        // Request SMS messages
         async requestSMS() {
           this.isLoading = true;
           const atcmd =
@@ -215,7 +211,7 @@
             if (!result.ok || !result.data) {
               const message = result.error
                 ? result.error.message
-                : "Impossibile recuperare gli SMS dal modem.";
+                : "Unable to retrieve SMS from the modem.";
               this.handleError(message, result.data);
               return;
             }
@@ -230,13 +226,13 @@
             this.showError = false;
             this.errorMessage = "";
           } catch (error) {
-            this.handleError(error.message || "Errore di rete durante il recupero degli SMS.");
+            this.handleError(error.message || "Network error while retrieving SMS.");
           } finally {
             this.isLoading = false;
           }
         },
 
-        // 解析短信数据的方法
+        // Parse SMS data
         parseSMSData(data) {
           const cmglRegex = /^\s*\+CMGL:\s*(\d+),"[^"]*","([^"]*)"[^"]*,"([^"]*)"/gm;
           const cscaRegex = /^\s*\+CSCA:\s*"([^"]*)"/gm;
@@ -283,23 +279,23 @@
           }
         },
 
-        // 将十六进制转换为文本（假设使用 UTF-16BE 编码）
+        // Convert hexadecimal to text (assuming UTF-16BE encoding)
         convertHexToText(hex) {
           const bytes = new Uint8Array(hex.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
           return new TextDecoder('utf-16be').decode(bytes);
         },
 
-        // 自定义解析日期函数
+        // Custom date parsing function
         parseCustomDate(dateStr) {
           const [datePart, timePart] = dateStr.split(',');
           const [day, month, year] = datePart.split('/').map(part => parseInt(part, 10));
           const [hour, minute, second] = timePart.split(':').map(part => parseInt(part, 10));
 
-          // 将日期转换为标准格式的日期对象
+          // Convert the date into a standard Date object
           return new Date(Date.UTC(2000 + year, month - 1, day, hour, minute, second));
         },
 
-        // 自定义格式化日期函数
+        // Custom date formatting function
         formatDate(date) {
           const year = date.getUTCFullYear() - 2000;
           const month = (date.getUTCMonth() + 1).toString().padStart(2, '0');
@@ -310,18 +306,18 @@
           return `${day}/${month}/${year},${hour}:${minute}:${second}`;
         },
 
-        // 删除选中的短信
+        // Delete selected SMS messages
         async deleteSelectedSMS() {
           if (this.selectedMessages.length === 0) {
-            console.warn("没有选中的短信");
+            console.warn("No SMS selected.");
             return;
           }
           if (!this.messageIndices || this.messageIndices.length === 0) {
-            console.error("短信索引未正确初始化或为空");
+            console.error("SMS indexes are not initialized correctly or are empty.");
             return;
           }
 
-          // 检查是否全选
+          // Check if all messages are selected
           const isAllSelected = this.selectedMessages.length === this.messages.length;
 
           if (isAllSelected) {
@@ -334,7 +330,7 @@
             indicesToDelete.push(...this.messages[index].indices);
           });
           if (indicesToDelete.length === 0) {
-            console.warn("没有有效的短信索引");
+            console.warn("No valid SMS indexes.");
             return;
           }
 
@@ -351,7 +347,7 @@
             if (!result.ok) {
               const message = result.error
                 ? result.error.message
-                : "Impossibile eliminare gli SMS selezionati.";
+                : "Unable to delete the selected SMS.";
               this.handleError(message, result.data);
               return;
             }
@@ -359,10 +355,10 @@
             this.selectedMessages = [];
             await this.requestSMS();
           } catch (error) {
-            this.handleError(error.message || "Errore di rete durante l'eliminazione degli SMS.");
+            this.handleError(error.message || "Network error while deleting SMS.");
           }
         },
-        // 删除所有短信
+        // Delete all SMS messages
         async deleteAllSMS() {
           try {
             const result = await ATCommandService.execute('AT+CMGD=,4', {
@@ -373,17 +369,17 @@
             if (!result.ok) {
               const message = result.error
                 ? result.error.message
-                : "Impossibile eliminare tutti gli SMS.";
+                : "Unable to delete all SMS.";
               this.handleError(message, result.data);
               return;
             }
 
             await this.requestSMS();
           } catch (error) {
-            this.handleError(error.message || "Errore di rete durante l'eliminazione degli SMS.");
+            this.handleError(error.message || "Network error while deleting SMS.");
           }
         },
-        // 发送短信
+        // Send SMS messages
         encodeUCS2(input) {
           let output = '';
           for (let i = 0; i < input.length; i++) {
@@ -402,8 +398,8 @@
             phoneNumberWithCountryCode = `${serviceCenterPrefix}${this.phoneNumber}`;
           }
           const encodedPhoneNumber = this.encodeUCS2(phoneNumberWithCountryCode);
-          const messageSegments = this.splitMessage(this.messageToSend, 70); // 将消息分段
-          const uid = Math.floor(Math.random() * 256); // 生成随机的UID
+          const messageSegments = this.splitMessage(this.messageToSend, 70); // Split the message into segments
+          const uid = Math.floor(Math.random() * 256); // Generate a random UID
           const totalSegments = messageSegments.length;
           let allSegmentsSent = true;
           let errorCode = null;
@@ -422,17 +418,17 @@
               const data = await response.text();
               console.log("Response from server:", data);
 
-              // 检查返回的数据中是否包含 '+CMS ERROR'
+              // Check whether the response contains '+CMS ERROR'
               if (data.includes('+CMS ERROR')) {
                 errorCode = data.match(/\+CMS ERROR: (\d+)/)?.[1];
                 console.error("SMS send error:", data);
                 allSegmentsSent = false;
-                break; // 停止发送剩余的段
+                break; // Stop sending remaining segments
               }
             } catch (error) {
               console.error("Fetch error:", error);
               allSegmentsSent = false;
-              break; // 停止发送剩余的段
+              break; // Stop sending remaining segments
             }
           }
           if (allSegmentsSent) {
@@ -457,20 +453,20 @@
           notification.style.display = 'block';
           setTimeout(() => {
             notification.style.display = 'none';
-          }, 3000); // 3秒后自动关闭
+          }, 3000); // Automatically hide after 3 seconds
         },
 
-        // 初始化
-        //   Initialize
+        // Initialize
         init() {
           this.clearData();
           this.requestSMS();
         },
 
-        // 全选/取消全选
-        //   Select all/deselect all
+        // Select all or deselect all
         toggleAll(event) {
-          this.selectedMessages = event.target.checked ? this.messages.map((_, index) => index) : [];
+          this.selectedMessages = event.target.checked
+            ? this.messages.map((_, index) => index)
+            : [];
         }
       };
     }


### PR DESCRIPTION
## Summary
- replace remaining Italian and Chinese UI strings with English labels and error messages across the dashboard, network, device info, settings, and SMS pages
- refresh shared JavaScript helpers with English diagnostics and remove leftover placeholder markup and comments from the UI templates

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6908b80186fc83279c67f7cabbe8e42e