### PR TITLE
feat: show real-time throughput stats

### DIFF
--- a/www/cgi-bin/get_interface_stats
+++ b/www/cgi-bin/get_interface_stats
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -euo pipefail
+
+urldecode() {
+  local data="${1//+/ }"
+  printf '%b' "${data//%/\\x}"
+}
+
+raw_query="${QUERY_STRING:-}"
+iface=""
+
+if [ -n "$raw_query" ]; then
+  IFS='&' read -r -a pairs <<< "$raw_query"
+  for pair in "${pairs[@]}"; do
+    key="${pair%%=*}"
+    value="${pair#*=}"
+    if [ "$key" = "iface" ]; then
+      iface="$(urldecode "$value")"
+    fi
+  done
+fi
+
+if [ -z "$iface" ]; then
+  iface="wwan0"
+fi
+
+if ! [[ "$iface" =~ ^[A-Za-z0-9_.:-]+$ ]]; then
+  printf 'Content-type: application/json\r\n\r\n'
+  printf '{"ok":false,"error":"Invalid interface name"}\n'
+  exit 0
+fi
+
+rx_path="/sys/class/net/$iface/statistics/rx_bytes"
+tx_path="/sys/class/net/$iface/statistics/tx_bytes"
+
+printf 'Content-type: application/json\r\n\r\n'
+
+if [ ! -r "$rx_path" ] || [ ! -r "$tx_path" ]; then
+  printf '{"ok":false,"error":"Interface not found","interface":"%s"}\n' "$iface"
+  exit 0
+fi
+
+if ! read -r rx_bytes < "$rx_path"; then
+  printf '{"ok":false,"error":"Unable to read rx_bytes","interface":"%s"}\n' "$iface"
+  exit 0
+fi
+
+if ! read -r tx_bytes < "$tx_path"; then
+  printf '{"ok":false,"error":"Unable to read tx_bytes","interface":"%s"}\n' "$iface"
+  exit 0
+fi
+
+if ! [[ "$rx_bytes" =~ ^[0-9]+$ ]] || ! [[ "$tx_bytes" =~ ^[0-9]+$ ]]; then
+  printf '{"ok":false,"error":"Invalid counter values","interface":"%s"}\n' "$iface"
+  exit 0
+fi
+
+printf '{"ok":true,"interface":"%s","rx_bytes":%s,"tx_bytes":%s}\n' \
+  "$iface" "$rx_bytes" "$tx_bytes"

--- a/www/index.html
+++ b/www/index.html
@@ -129,9 +129,22 @@
                     d="M576 0c17.7 0 32 14.3 32 32V480c0 17.7-14.3 32-32 32s-32-14.3-32-32V32c0-17.7 14.3-32 32-32zM448 96c17.7 0 32 14.3 32 32V480c0 17.7-14.3 32-32 32s-32-14.3-32-32V128c0-17.7 14.3-32 32-32zM352 224V480c0 17.7-14.3 32-32 32s-32-14.3-32-32V224c0-17.7 14.3-32 32-32s32 14.3 32 32zM192 288c17.7 0 32 14.3 32 32V480c0 17.7-14.3 32-32 32s-32-14.3-32-32V320c0-17.7 14.3-32 32-32zM96 416v64c0 17.7-14.3 32-32 32s-32-14.3-32-32V416c0-17.7 14.3-32 32-32s32 14.3 32 32z"
                   />
                 </svg>
-                <h1 class="card-text mt-4" x-text="signalPercentage + '%'"></h1>
+                <div class="card-text mt-4 w-100">
+                  <div class="d-flex flex-column align-items-center gap-2">
+                    <div class="d-flex align-items-center gap-2">
+                      <span class="fs-4" aria-hidden="true">&#8595;</span>
+                      <span class="text-uppercase small text-muted">Download</span>
+                      <span class="fs-3 fw-semibold" x-text="downloadSpeed"></span>
+                    </div>
+                    <div class="d-flex align-items-center gap-2">
+                      <span class="fs-4" aria-hidden="true">&#8593;</span>
+                      <span class="text-uppercase small text-muted">Upload</span>
+                      <span class="fs-3 fw-semibold" x-text="uploadSpeed"></span>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div class="card-footer">Signal Percentage</div>
+              <div class="card-footer">Current Traffic</div>
             </div>
           </div>
 
@@ -827,6 +840,17 @@
           "22299": "Wind Tre",
         };
 
+        const TRAFFIC_INTERFACE_CANDIDATES = [
+          "wwan0",
+          "rmnet_data0",
+          "rmnet_data1",
+          "rmnet_data2",
+          "rmnet0",
+          "usb0",
+          "eth0",
+          "ppp0",
+        ];
+
         const defaultDataState = {
           atcmd: "",
           internetConnectionStatus: "Disconnected",
@@ -876,6 +900,12 @@
           nonNrUpload: "0",
           downloadStat: "0",
           uploadStat: "0",
+          downloadSpeed: "–",
+          uploadSpeed: "–",
+          previousDownloadBytes: null,
+          previousUploadBytes: null,
+          lastCountersTimestamp: null,
+          trafficInterface: null,
           detailedSignals: [],
           intervalId: null,
         };
@@ -888,6 +918,12 @@
               refreshRate: this.refreshRate,
               newRefreshRate: this.newRefreshRate,
               intervalId: this.intervalId,
+              trafficInterface: this.trafficInterface,
+              downloadSpeed: this.downloadSpeed,
+              uploadSpeed: this.uploadSpeed,
+              previousDownloadBytes: this.previousDownloadBytes,
+              previousUploadBytes: this.previousUploadBytes,
+              lastCountersTimestamp: this.lastCountersTimestamp,
             };
 
             Object.assign(
@@ -920,6 +956,8 @@
           async fetchAllInfo() {
             this.atcmd =
               'AT^TEMP?;^SWITCH_SLOT?;+CGPIAF=1,1,1,1;^DEBUG?;+CPIN?;+CGCONTRDP=1;$QCSIMSTAT?;+CSQ;';
+
+            await this.updateInterfaceSpeeds();
 
             try {
               const result = await ATCommandService.execute(this.atcmd, {
@@ -2063,6 +2101,142 @@
             }
           },
 
+          async requestInterfaceCounters(iface) {
+            try {
+              const params = new URLSearchParams();
+              if (iface) {
+                params.set("iface", iface);
+              }
+
+              const query = params.toString();
+              const endpoint = query
+                ? `/cgi-bin/get_interface_stats?${query}`
+                : "/cgi-bin/get_interface_stats";
+
+              const response = await fetch(endpoint);
+              if (!response.ok) {
+                return null;
+              }
+
+              const payload = await response.json();
+              if (!payload || payload.ok === false) {
+                return null;
+              }
+
+              const downloadBytes = Number.parseInt(payload.rx_bytes, 10);
+              const uploadBytes = Number.parseInt(payload.tx_bytes, 10);
+
+              if (
+                !Number.isFinite(downloadBytes) ||
+                !Number.isFinite(uploadBytes) ||
+                downloadBytes < 0 ||
+                uploadBytes < 0
+              ) {
+                return null;
+              }
+
+              return {
+                interface: payload.interface || iface || null,
+                downloadBytes,
+                uploadBytes,
+              };
+            } catch (error) {
+              console.error(`Failed to fetch interface stats for ${iface}`, error);
+              return null;
+            }
+          },
+
+          async updateInterfaceSpeeds() {
+            const candidates = [];
+
+            if (this.trafficInterface) {
+              candidates.push(this.trafficInterface);
+            }
+
+            for (const candidate of TRAFFIC_INTERFACE_CANDIDATES) {
+              if (!candidates.includes(candidate)) {
+                candidates.push(candidate);
+              }
+            }
+
+            let counters = null;
+
+            for (const iface of candidates) {
+              const result = await this.requestInterfaceCounters(iface);
+              if (result) {
+                counters = result;
+                break;
+              }
+            }
+
+            if (!counters) {
+              this.downloadSpeed = defaultDataState.downloadSpeed;
+              this.uploadSpeed = defaultDataState.uploadSpeed;
+              this.previousDownloadBytes = null;
+              this.previousUploadBytes = null;
+              this.lastCountersTimestamp = null;
+              return;
+            }
+
+            if (counters.interface) {
+              this.trafficInterface = counters.interface;
+            }
+
+            const now = Date.now();
+
+            if (
+              this.previousDownloadBytes !== null &&
+              this.previousUploadBytes !== null &&
+              this.lastCountersTimestamp !== null &&
+              now > this.lastCountersTimestamp
+            ) {
+              const elapsedSeconds = (now - this.lastCountersTimestamp) / 1000;
+
+              if (elapsedSeconds > 0) {
+                let downloadDelta = counters.downloadBytes - this.previousDownloadBytes;
+                let uploadDelta = counters.uploadBytes - this.previousUploadBytes;
+
+                if (downloadDelta < 0) {
+                  downloadDelta = 0;
+                }
+
+                if (uploadDelta < 0) {
+                  uploadDelta = 0;
+                }
+
+                const downloadRate = downloadDelta / elapsedSeconds;
+                const uploadRate = uploadDelta / elapsedSeconds;
+
+                this.downloadSpeed = this.formatSpeed(downloadRate);
+                this.uploadSpeed = this.formatSpeed(uploadRate);
+              }
+            } else {
+              this.downloadSpeed = "0 B/s";
+              this.uploadSpeed = "0 B/s";
+            }
+
+            this.previousDownloadBytes = counters.downloadBytes;
+            this.previousUploadBytes = counters.uploadBytes;
+            this.lastCountersTimestamp = now;
+          },
+
+          formatSpeed(bytesPerSecond) {
+            if (!Number.isFinite(bytesPerSecond) || bytesPerSecond <= 0) {
+              return "0 B/s";
+            }
+
+            const units = ["B/s", "KB/s", "MB/s", "GB/s", "TB/s"];
+            let value = bytesPerSecond;
+            let unitIndex = 0;
+
+            while (value >= 1024 && unitIndex < units.length - 1) {
+              value /= 1024;
+              unitIndex += 1;
+            }
+
+            const decimals = value >= 100 ? 0 : value >= 10 ? 1 : 2;
+            return `${value.toFixed(decimals)} ${units[unitIndex]}`;
+          },
 
           bytesToSize(bytes) {
             const sizes = ["Bytes", "KB", "MB", "GB", "TB"];


### PR DESCRIPTION
## Summary
- display live download and upload throughput in the home dashboard card
- poll interface counters through a new CGI helper and compute speeds in the frontend state

## Testing
- QUERY_STRING='iface=eth0' ./www/cgi-bin/get_interface_stats

------
https://chatgpt.com/codex/tasks/task_e_690a0b23ce7c832796c9a4e46e0dffae