### PR TITLE
Add LAN and DHCP configuration controls to network tab

### DIFF
--- a/www/cgi-bin/get_network_config
+++ b/www/cgi-bin/get_network_config
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG_FILE="/etc/data/mobileap_cfg.xml"
+
+get_xml_value() {
+    local key=$1
+    local file=$2
+    local value
+
+    value=$(grep "<$key>" "$file" | sed "s/.*<$key>\(.*\)<\/$key>.*/\1/" | tr -d ' ')
+    echo "$value"
+}
+
+output_json() {
+    local ip=$1
+    local subnet=$2
+    local dhcp_enabled=$3
+    local dhcp_start=$4
+    local dhcp_end=$5
+    local lease_time=$6
+
+    cat <<JSON
+Content-type: application/json
+
+{
+  "ip": "${ip}",
+  "subnet": "${subnet}",
+  "dhcpEnabled": "${dhcp_enabled}",
+  "dhcpStart": "${dhcp_start}",
+  "dhcpEnd": "${dhcp_end}",
+  "leaseTime": "${lease_time}"
+}
+JSON
+}
+
+main() {
+    if [ ! -f "$CONFIG_FILE" ]; then
+        cat <<JSON
+Content-type: application/json
+
+{
+  "error": "Configuration file not found"
+}
+JSON
+        exit 0
+    fi
+
+    local ip subnet dhcp_enabled dhcp_start dhcp_end lease_time
+    ip=$(get_xml_value "APIPAddr" "$CONFIG_FILE")
+    subnet=$(get_xml_value "SubNetMask" "$CONFIG_FILE")
+    dhcp_enabled=$(get_xml_value "EnableDHCPServer" "$CONFIG_FILE")
+    dhcp_start=$(get_xml_value "StartIP" "$CONFIG_FILE")
+    dhcp_end=$(get_xml_value "EndIP" "$CONFIG_FILE")
+    lease_time=$(get_xml_value "LeaseTime" "$CONFIG_FILE")
+
+    output_json "${ip:-}" "${subnet:-}" "${dhcp_enabled:-}" "${dhcp_start:-}" "${dhcp_end:-}" "${lease_time:-}"
+}
+
+main "$@"

--- a/www/cgi-bin/set_network_config
+++ b/www/cgi-bin/set_network_config
@@ -1,0 +1,190 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG_FILE="/etc/data/mobileap_cfg.xml"
+TMP_FILE="/tmp/mobileap_cfg_tmp.xml"
+
+send_response() {
+    local status=$1
+    local message=$2
+    cat <<JSON
+Content-type: application/json
+
+{ "ok": ${status}, "message": "${message}" }
+JSON
+}
+
+urldecode() {
+    local data="${1//+/ }"
+    printf '%b' "${data//%/\\x}"
+}
+
+parse_input() {
+    local raw="$1"
+    local key value
+    local -a pairs=()
+
+    IFS='&' read -ra pairs <<< "$raw"
+    for kv in "${pairs[@]}"; do
+        key=${kv%%=*}
+        value=${kv#*=}
+        [ -z "$key" ] && continue
+        value=$(urldecode "$value")
+        case "$key" in
+            ip) IP_VALUE="$value" ;;
+            subnet) SUBNET_VALUE="$value" ;;
+            dhcpEnabled) DHCP_ENABLED_VALUE="$value" ;;
+            dhcpStart) DHCP_START_VALUE="$value" ;;
+            dhcpEnd) DHCP_END_VALUE="$value" ;;
+            dhcpLease) DHCP_LEASE_VALUE="$value" ;;
+        esac
+    done
+}
+
+is_valid_ipv4() {
+    local ip=$1
+    local IFS='.'
+    local -a octets
+    read -r -a octets <<< "$ip"
+
+    if [ "${#octets[@]}" -ne 4 ]; then
+        return 1
+    fi
+
+    for octet in "${octets[@]}"; do
+        if ! [[ $octet =~ ^[0-9]+$ ]]; then
+            return 1
+        fi
+        if [ "$octet" -lt 0 ] || [ "$octet" -gt 255 ]; then
+            return 1
+        fi
+    done
+
+    return 0
+}
+
+is_valid_netmask() {
+    local mask=$1
+    case "$mask" in
+        255.255.255.255|255.255.255.254|255.255.255.252|255.255.255.248|
+        255.255.255.240|255.255.255.224|255.255.255.192|255.255.255.128|
+        255.255.255.0|255.255.254.0|255.255.252.0|255.255.248.0|
+        255.255.240.0|255.255.224.0|255.255.192.0|255.255.128.0|
+        255.255.0.0|255.254.0.0|255.252.0.0|255.248.0.0|
+        255.240.0.0|255.224.0.0|255.192.0.0|255.128.0.0|
+        255.0.0.0|254.0.0.0|252.0.0.0|248.0.0.0|
+        240.0.0.0|224.0.0.0|192.0.0.0|128.0.0.0|0.0.0.0)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+ip_to_int() {
+    local IFS='.'
+    local -a octets
+    read -r -a octets <<< "$1"
+    printf '%u' $(( (octets[0] << 24) + (octets[1] << 16) + (octets[2] << 8) + octets[3] ))
+}
+
+apply_value() {
+    local key=$1
+    local value=$2
+
+    if grep -q "<$key>" "$CONFIG_FILE"; then
+        sed "s|<$key>.*</$key>|<$key>$value</$key>|" "$CONFIG_FILE" > "$TMP_FILE"
+        mv "$TMP_FILE" "$CONFIG_FILE"
+    fi
+}
+
+main() {
+    if [ ! -f "$CONFIG_FILE" ]; then
+        send_response false "Configuration file not found"
+        exit 0
+    fi
+
+    local data=""
+
+    if [ "${REQUEST_METHOD:-GET}" = "POST" ]; then
+        if [ -n "${CONTENT_LENGTH:-}" ]; then
+            read -r -n "$CONTENT_LENGTH" data
+        else
+            read -r data
+        fi
+    else
+        data=$QUERY_STRING
+    fi
+
+    parse_input "$data"
+
+    IP_VALUE=${IP_VALUE:-}
+    SUBNET_VALUE=${SUBNET_VALUE:-}
+    DHCP_ENABLED_VALUE=${DHCP_ENABLED_VALUE:-}
+    DHCP_START_VALUE=${DHCP_START_VALUE:-}
+    DHCP_END_VALUE=${DHCP_END_VALUE:-}
+    DHCP_LEASE_VALUE=${DHCP_LEASE_VALUE:-}
+
+    if [ -z "$IP_VALUE" ] || ! is_valid_ipv4 "$IP_VALUE"; then
+        send_response false "Indirizzo IP non valido"
+        exit 0
+    fi
+
+    if [ -z "$SUBNET_VALUE" ] || ! is_valid_netmask "$SUBNET_VALUE"; then
+        send_response false "Subnet mask non valida"
+        exit 0
+    fi
+
+    if [ -z "$DHCP_ENABLED_VALUE" ] || ! [[ "$DHCP_ENABLED_VALUE" =~ ^[01]$ ]]; then
+        send_response false "Valore DHCP non valido"
+        exit 0
+    fi
+
+    if [ "$DHCP_ENABLED_VALUE" = "1" ]; then
+        if [ -z "$DHCP_START_VALUE" ] || ! is_valid_ipv4 "$DHCP_START_VALUE"; then
+            send_response false "Indirizzo iniziale DHCP non valido"
+            exit 0
+        fi
+        if [ -z "$DHCP_END_VALUE" ] || ! is_valid_ipv4 "$DHCP_END_VALUE"; then
+            send_response false "Indirizzo finale DHCP non valido"
+            exit 0
+        fi
+
+        local ip_int start_int end_int
+        ip_int=$(ip_to_int "$IP_VALUE")
+        start_int=$(ip_to_int "$DHCP_START_VALUE")
+        end_int=$(ip_to_int "$DHCP_END_VALUE")
+
+        if [ "$start_int" -gt "$end_int" ]; then
+            send_response false "L'indirizzo iniziale DHCP deve essere precedente o uguale all'indirizzo finale"
+            exit 0
+        fi
+    fi
+
+    if [ -n "$DHCP_LEASE_VALUE" ]; then
+        if ! [[ "$DHCP_LEASE_VALUE" =~ ^[0-9]+$ ]]; then
+            send_response false "Lease time non valido"
+            exit 0
+        fi
+    else
+        DHCP_LEASE_VALUE="86400"
+    fi
+
+    apply_value "APIPAddr" "$IP_VALUE"
+    apply_value "SubNetMask" "$SUBNET_VALUE"
+    apply_value "EnableDHCPServer" "$DHCP_ENABLED_VALUE"
+
+    if [ "$DHCP_ENABLED_VALUE" = "1" ]; then
+        apply_value "StartIP" "$DHCP_START_VALUE"
+        apply_value "EndIP" "$DHCP_END_VALUE"
+    fi
+
+    apply_value "LeaseTime" "$DHCP_LEASE_VALUE"
+
+    sync
+
+    send_response true "Configurazione aggiornata"
+}
+
+main "$@"

--- a/www/network.html
+++ b/www/network.html
@@ -152,6 +152,16 @@
                       SIM Management
                     </button>
                   </li>
+                  <li class="nav-item" role="presentation">
+                    <button
+                      type="button"
+                      class="nav-link"
+                      :class="{ active: activeUtilityTab === 'lan' }"
+                      @click="activeUtilityTab = 'lan'"
+                    >
+                      LAN &amp; DHCP
+                    </button>
+                  </li>
                 </ul>
               </div>
               <div class="card-body">
@@ -257,6 +267,103 @@
                     </div>
                   </div>
                 </div>
+
+                <div x-show="activeUtilityTab === 'lan'">
+                  <div class="row">
+                    <div class="col-lg-6">
+                      <div class="mb-4">
+                        <label for="lanIp" class="form-label">Indirizzo IP LAN</label>
+                        <input
+                          type="text"
+                          class="form-control"
+                          id="lanIp"
+                          x-model="pendingLanIp"
+                          @change="handleLanIpChange"
+                          placeholder="192.168.1.1"
+                        />
+                        <small class="text-body-secondary"
+                          >Attuale: <span x-text="lanIp === '-' ? 'Caricamento…' : lanIp"></span></small
+                        >
+                      </div>
+
+                      <div class="mb-4">
+                        <label for="lanSubnet" class="form-label">Subnet mask</label>
+                        <input
+                          type="text"
+                          class="form-control"
+                          id="lanSubnet"
+                          x-model="pendingLanSubnet"
+                          placeholder="255.255.255.0"
+                        />
+                        <small class="text-body-secondary"
+                          >Attuale: <span x-text="lanSubnet === '-' ? 'Caricamento…' : lanSubnet"></span></small
+                        >
+                      </div>
+
+                      <div class="form-check form-switch mb-4">
+                        <input
+                          class="form-check-input"
+                          type="checkbox"
+                          role="switch"
+                          id="dhcpEnabled"
+                          x-model="pendingLanDhcpEnabled"
+                          @change="handleDhcpToggle"
+                        />
+                        <label class="form-check-label" for="dhcpEnabled"
+                          >Abilita server DHCP</label
+                        >
+                      </div>
+                    </div>
+
+                    <div class="col-lg-6">
+                      <template x-if="pendingLanDhcpEnabled">
+                        <div>
+                          <div class="mb-4">
+                            <label for="dhcpStart" class="form-label">IP iniziale DHCP</label>
+                            <input
+                              type="text"
+                              class="form-control"
+                              id="dhcpStart"
+                              x-model="pendingLanDhcpStart"
+                              @input="markDhcpRangeEdited"
+                              placeholder="192.168.1.20"
+                            />
+                          </div>
+
+                          <div class="mb-4">
+                            <label for="dhcpEnd" class="form-label">IP finale DHCP</label>
+                            <input
+                              type="text"
+                              class="form-control"
+                              id="dhcpEnd"
+                              x-model="pendingLanDhcpEnd"
+                              @input="markDhcpRangeEdited"
+                              placeholder="192.168.1.60"
+                            />
+                          </div>
+                        </div>
+                      </template>
+
+                      <div class="mb-4">
+                        <label for="dhcpLease" class="form-label">Lease time (secondi)</label>
+                        <input
+                          type="text"
+                          class="form-control"
+                          id="dhcpLease"
+                          x-model="pendingLanLease"
+                          placeholder="86400"
+                        />
+                        <small class="text-body-secondary"
+                          >Attuale: <span x-text="lanLeaseTime === '-' ? 'Caricamento…' : lanLeaseTime"></span></small
+                        >
+                      </div>
+
+                      <p class="text-body-secondary">
+                        Salvando la configurazione il modem verrà riavviato per applicare le modifiche.
+                      </p>
+                    </div>
+                  </div>
+                </div>
               </div>
               <div class="card-footer d-flex justify-content-end gap-2">
                 <button
@@ -274,6 +381,16 @@
                   x-show="activeUtilityTab === 'apn'"
                 >
                   Save Changes
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-primary"
+                  @click="saveLanSettings()"
+                  x-show="activeUtilityTab === 'lan'"
+                  :disabled="isSavingLanSettings || !lanSettingsLoaded"
+                >
+                  <span x-show="isSavingLanSettings">Salvataggio…</span>
+                  <span x-show="!isSavingLanSettings">Salva LAN &amp; DHCP</span>
                 </button>
                 <button
                   type="button"
@@ -501,6 +618,21 @@
           rawdata: "",
           networkModeListenerAttached: false,
           providerBandsListenerAttached: false,
+          lanIp: "-",
+          lanSubnet: "-",
+          lanDhcpEnabled: "0",
+          lanDhcpStart: "-",
+          lanDhcpEnd: "-",
+          lanLeaseTime: "-",
+          pendingLanIp: "",
+          pendingLanSubnet: "",
+          pendingLanDhcpEnabled: false,
+          pendingLanDhcpStart: "",
+          pendingLanDhcpEnd: "",
+          pendingLanLease: "",
+          lanSettingsLoaded: false,
+          lanDhcpRangeManuallyEdited: false,
+          isSavingLanSettings: false,
           parseApnContexts(rawData) {
             if (typeof rawData !== "string") {
               return [];
@@ -527,6 +659,370 @@
               })
               .filter(Boolean)
               .sort((a, b) => a.cid - b.cid);
+          },
+          async loadLanSettings() {
+            try {
+              const response = await fetch("/cgi-bin/get_network_config", {
+                headers: {
+                  "Cache-Control": "no-cache",
+                },
+              });
+
+              if (!response.ok) {
+                throw new Error(`HTTP ${response.status}`);
+              }
+
+              const data = await response.json();
+
+              if (data && data.error) {
+                throw new Error(data.error);
+              }
+
+              this.lanIp = data && data.ip ? data.ip : "-";
+              this.lanSubnet = data && data.subnet ? data.subnet : "-";
+              this.lanDhcpEnabled = data && data.dhcpEnabled ? data.dhcpEnabled : "0";
+              this.lanDhcpStart = data && data.dhcpStart ? data.dhcpStart : "-";
+              this.lanDhcpEnd = data && data.dhcpEnd ? data.dhcpEnd : "-";
+
+              const leaseRaw =
+                data && Object.prototype.hasOwnProperty.call(data, "leaseTime")
+                  ? String(data.leaseTime)
+                  : "";
+              const leaseValue = leaseRaw !== "" ? leaseRaw : "86400";
+              this.lanLeaseTime = leaseValue;
+
+              this.pendingLanIp = this.lanIp === "-" ? "" : this.lanIp;
+              this.pendingLanSubnet = this.lanSubnet === "-" ? "" : this.lanSubnet;
+              this.pendingLanDhcpEnabled = this.lanDhcpEnabled === "1";
+              this.pendingLanDhcpStart = this.lanDhcpStart === "-" ? "" : this.lanDhcpStart;
+              this.pendingLanDhcpEnd = this.lanDhcpEnd === "-" ? "" : this.lanDhcpEnd;
+              this.pendingLanLease = leaseValue;
+
+              if (this.pendingLanDhcpEnabled) {
+                if (!this.pendingLanDhcpStart && !this.pendingLanDhcpEnd) {
+                  this.autoFillDhcpRangeFromIp(this.pendingLanIp);
+                  this.lanDhcpRangeManuallyEdited = false;
+                } else {
+                  this.lanDhcpRangeManuallyEdited = true;
+                }
+              } else {
+                this.lanDhcpRangeManuallyEdited = false;
+              }
+
+              this.lanSettingsLoaded = true;
+            } catch (error) {
+              console.error("Unable to load LAN configuration:", error);
+              this.lastErrorMessage =
+                error.message || "Impossibile recuperare la configurazione LAN.";
+              alert(this.lastErrorMessage);
+              this.pendingLanLease = this.pendingLanLease || "86400";
+              this.lanSettingsLoaded = true;
+            }
+          },
+          handleLanIpChange() {
+            const ip = (this.pendingLanIp || "").trim();
+
+            if (!this.isValidIpv4(ip)) {
+              return;
+            }
+
+            if (!this.pendingLanDhcpEnabled) {
+              return;
+            }
+
+            this.lanDhcpRangeManuallyEdited = false;
+            this.autoFillDhcpRangeFromIp(ip);
+          },
+          handleDhcpToggle() {
+            if (this.pendingLanDhcpEnabled) {
+              this.lanDhcpRangeManuallyEdited = false;
+              this.handleLanIpChange();
+            } else {
+              this.pendingLanDhcpStart = "";
+              this.pendingLanDhcpEnd = "";
+              this.lanDhcpRangeManuallyEdited = false;
+            }
+          },
+          markDhcpRangeEdited() {
+            this.lanDhcpRangeManuallyEdited = true;
+          },
+          autoFillDhcpRangeFromIp(ip) {
+            const parts = (ip || "").split(".");
+
+            if (parts.length !== 4) {
+              return;
+            }
+
+            const prefix = parts.slice(0, 3).join(".");
+            this.pendingLanDhcpStart = `${prefix}.20`;
+            this.pendingLanDhcpEnd = `${prefix}.60`;
+          },
+          isValidIpv4(value) {
+            if (typeof value !== "string") {
+              return false;
+            }
+
+            const parts = value.trim().split(".");
+
+            if (parts.length !== 4) {
+              return false;
+            }
+
+            return parts.every((part) => {
+              if (!/^\d+$/.test(part)) {
+                return false;
+              }
+
+              const number = Number(part);
+              return number >= 0 && number <= 255;
+            });
+          },
+          isValidNetmask(value) {
+            if (typeof value !== "string") {
+              return false;
+            }
+
+            const masks = new Set([
+              "255.255.255.255",
+              "255.255.255.254",
+              "255.255.255.252",
+              "255.255.255.248",
+              "255.255.255.240",
+              "255.255.255.224",
+              "255.255.255.192",
+              "255.255.255.128",
+              "255.255.255.0",
+              "255.255.254.0",
+              "255.255.252.0",
+              "255.255.248.0",
+              "255.255.240.0",
+              "255.255.224.0",
+              "255.255.192.0",
+              "255.255.128.0",
+              "255.255.0.0",
+              "255.254.0.0",
+              "255.252.0.0",
+              "255.248.0.0",
+              "255.240.0.0",
+              "255.224.0.0",
+              "255.192.0.0",
+              "255.128.0.0",
+              "255.0.0.0",
+              "254.0.0.0",
+              "252.0.0.0",
+              "248.0.0.0",
+              "240.0.0.0",
+              "224.0.0.0",
+              "192.0.0.0",
+              "128.0.0.0",
+              "0.0.0.0",
+            ]);
+
+            return masks.has(value.trim());
+          },
+          ipv4ToInt(value) {
+            if (!this.isValidIpv4(value)) {
+              return null;
+            }
+
+            const parts = value.trim().split(".").map((part) => Number(part));
+            return (
+              ((parts[0] << 24) >>> 0) +
+              ((parts[1] << 16) >>> 0) +
+              ((parts[2] << 8) >>> 0) +
+              (parts[3] >>> 0)
+            ) >>> 0;
+          },
+          compareIpv4(a, b) {
+            const aInt = this.ipv4ToInt(a);
+            const bInt = this.ipv4ToInt(b);
+
+            if (aInt === null || bInt === null) {
+              return 0;
+            }
+
+            return aInt - bInt;
+          },
+          isInSameSubnet(ip, mask, target) {
+            const ipInt = this.ipv4ToInt(ip);
+            const maskInt = this.ipv4ToInt(mask);
+            const targetInt = this.ipv4ToInt(target);
+
+            if (ipInt === null || maskInt === null || targetInt === null) {
+              return false;
+            }
+
+            return (ipInt & maskInt) === (targetInt & maskInt);
+          },
+          validateLanSettings() {
+            const ip = (this.pendingLanIp || "").trim();
+            const subnet = (this.pendingLanSubnet || "").trim();
+            const lease = (this.pendingLanLease || "").trim();
+
+            if (!this.isValidIpv4(ip)) {
+              return {
+                ok: false,
+                message: "Inserisci un indirizzo IP LAN valido.",
+              };
+            }
+
+            if (!this.isValidNetmask(subnet)) {
+              return {
+                ok: false,
+                message: "Inserisci una subnet mask valida.",
+              };
+            }
+
+            if (lease && !/^\d+$/.test(lease)) {
+              return {
+                ok: false,
+                message: "Inserisci un lease time valido (solo numeri).",
+              };
+            }
+
+            let dhcpStart = (this.pendingLanDhcpStart || "").trim();
+            let dhcpEnd = (this.pendingLanDhcpEnd || "").trim();
+            const dhcpEnabledValue = this.pendingLanDhcpEnabled ? "1" : "0";
+
+            if (dhcpEnabledValue === "1") {
+              if (!this.isValidIpv4(dhcpStart)) {
+                return {
+                  ok: false,
+                  message: "Inserisci un IP iniziale DHCP valido.",
+                };
+              }
+
+              if (!this.isValidIpv4(dhcpEnd)) {
+                return {
+                  ok: false,
+                  message: "Inserisci un IP finale DHCP valido.",
+                };
+              }
+
+              if (this.compareIpv4(dhcpStart, dhcpEnd) > 0) {
+                return {
+                  ok: false,
+                  message:
+                    "L'indirizzo iniziale del DHCP deve essere precedente o uguale all'indirizzo finale.",
+                };
+              }
+
+              if (
+                !this.isInSameSubnet(ip, subnet, dhcpStart) ||
+                !this.isInSameSubnet(ip, subnet, dhcpEnd)
+              ) {
+                return {
+                  ok: false,
+                  message:
+                    "Gli indirizzi DHCP devono appartenere alla stessa subnet dell'indirizzo LAN.",
+                };
+              }
+            } else {
+              dhcpStart = "";
+              dhcpEnd = "";
+            }
+
+            return {
+              ok: true,
+              payload: {
+                ip,
+                subnet,
+                dhcpEnabled: dhcpEnabledValue,
+                dhcpStart,
+                dhcpEnd,
+                lease: lease || "86400",
+              },
+            };
+          },
+          async saveLanSettings() {
+            if (this.isSavingLanSettings) {
+              return;
+            }
+
+            const validation = this.validateLanSettings();
+
+            if (!validation.ok) {
+              alert(validation.message);
+              return;
+            }
+
+            const payload = validation.payload;
+
+            this.isSavingLanSettings = true;
+
+            try {
+              const params = new URLSearchParams({
+                ip: payload.ip,
+                subnet: payload.subnet,
+                dhcpEnabled: payload.dhcpEnabled,
+              });
+
+              if (payload.dhcpEnabled === "1") {
+                params.set("dhcpStart", payload.dhcpStart);
+                params.set("dhcpEnd", payload.dhcpEnd);
+              }
+
+              if (payload.lease) {
+                params.set("dhcpLease", payload.lease);
+              }
+
+              const response = await fetch("/cgi-bin/set_network_config", {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/x-www-form-urlencoded",
+                },
+                body: params.toString(),
+              });
+
+              const data = await response.json().catch(() => ({}));
+
+              if (!response.ok || !data || !data.ok) {
+                const message =
+                  data && data.message
+                    ? data.message
+                    : "Impossibile salvare la configurazione LAN.";
+                throw new Error(message);
+              }
+
+              this.lanIp = payload.ip;
+              this.lanSubnet = payload.subnet;
+              this.lanDhcpEnabled = payload.dhcpEnabled;
+              this.lanLeaseTime = payload.lease;
+
+              if (payload.dhcpEnabled === "1") {
+                this.lanDhcpStart = payload.dhcpStart;
+                this.lanDhcpEnd = payload.dhcpEnd;
+              } else {
+                this.lanDhcpStart = "-";
+                this.lanDhcpEnd = "-";
+              }
+
+              this.pendingLanIp = payload.ip;
+              this.pendingLanSubnet = payload.subnet;
+              this.pendingLanDhcpEnabled = payload.dhcpEnabled === "1";
+              this.pendingLanDhcpStart = payload.dhcpStart;
+              this.pendingLanDhcpEnd = payload.dhcpEnd;
+              this.pendingLanLease = payload.lease;
+              this.lanDhcpRangeManuallyEdited = false;
+
+              alert(
+                "Configurazione salvata. Il modem verrà riavviato per applicare le modifiche."
+              );
+
+              const restartResult = await this.sendATcommand("AT+CFUN=1,1");
+
+              if (!restartResult.ok) {
+                alert(
+                  this.lastErrorMessage ||
+                    "Impossibile riavviare automaticamente il modem. Riavvia manualmente per applicare le modifiche."
+                );
+              }
+            } catch (error) {
+              console.error("Unable to save LAN configuration:", error);
+              alert(error.message || "Impossibile salvare la configurazione LAN.");
+            } finally {
+              this.isSavingLanSettings = false;
+            }
           },
           async ensurePrimaryApnProfile() {
             const response = await this.sendATcommand('AT+CGDCONT?');
@@ -870,6 +1366,7 @@
             showPopulateCheckboxes();
             addNetworkModeListener();
             addProviderBandsListener();
+            this.loadLanSettings();
           },
           async getCurrentSettings() {
             const atcmd =


### PR DESCRIPTION
## Summary
- add a LAN & DHCP tab in the network page so the modem subnet and DHCP pool can be edited from the UI
- expose CGI helpers to read the current mobileap_cfg.xml values and persist user changes safely
- trigger a modem restart after saving to apply the updated network configuration

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f524094ec83279ad452a18e329681)