### PR TITLE
Fix network settings CGI fallback when repo root unavailable

### DIFF
--- a/www/cgi-bin/network_settings
+++ b/www/cgi-bin/network_settings
@@ -17,11 +17,12 @@ def resolve_config_path() -> Path:
         return Path(override).expanduser()
 
     script_path = Path(__file__).resolve()
-    repo_root = script_path.parents[2]
-    fallback_candidates = [
-        DEFAULT_CONFIG_PATH,
-        repo_root / "Default config files" / "mobileap_cfg.xml",
-    ]
+    parents = script_path.parents
+    repo_root = parents[2] if len(parents) > 2 else None
+    fallback_candidates = [DEFAULT_CONFIG_PATH]
+
+    if repo_root is not None:
+        fallback_candidates.append(repo_root / "Default config files" / "mobileap_cfg.xml")
 
     for candidate in fallback_candidates:
         if candidate.exists():


### PR DESCRIPTION
## Summary
- guard the fallback repo-root detection in the network_settings CGI script so it works when deployed outside the repository tree

## Testing
- python3 www/cgi-bin/network_settings

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5d691b1083278b82a27c6e299b1c)