### PR TITLE
Point network settings CGI at modem config location

### DIFF
--- a/www/cgi-bin/network_settings
+++ b/www/cgi-bin/network_settings
@@ -16,17 +16,6 @@ def resolve_config_path() -> Path:
     if override:
         return Path(override).expanduser()
 
-    script_path = Path(__file__).resolve()
-    repo_root = script_path.parents[2]
-    fallback_candidates = [
-        DEFAULT_CONFIG_PATH,
-        repo_root / "Default config files" / "mobileap_cfg.xml",
-    ]
-
-    for candidate in fallback_candidates:
-        if candidate.exists():
-            return candidate
-
     return DEFAULT_CONFIG_PATH
 
 
@@ -54,7 +43,7 @@ def load_configuration() -> str:
         with CONFIG_PATH.open("r", encoding="utf-8") as handle:
             return handle.read()
     except OSError:
-        respond(False, "Configuration file not found.")
+        respond(False, f"Configuration file not found at {CONFIG_PATH}.")
         sys.exit(0)
 
 


### PR DESCRIPTION
## Summary
- remove repository fallback when resolving the modem configuration
- clarify the missing-file error message with the absolute path that was expected

## Testing
- python3 www/cgi-bin/network_settings

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f5d691b1083278b82a27c6e299b1c)