### PR TITLE
Handle self-closing XML tags when updating network settings

### DIFF
--- a/www/cgi-bin/network_settings
+++ b/www/cgi-bin/network_settings
@@ -78,11 +78,15 @@ set_xml_value() {
     local value="$2"
     local file="$3"
 
-    if ! grep -q "<$key>" "$file"; then
-        return 1
-    fi
-
-    if ! sed "s|<$key>.*</$key>|<$key>$value</$key>|" "$file" > "$TMP_FILE"; then
+    if grep -q "<$key>" "$file"; then
+        if ! sed "s|<$key>.*</$key>|<$key>$value</$key>|" "$file" > "$TMP_FILE"; then
+            return 1
+        fi
+    elif grep -Eq "<$key[[:space:]]*/>" "$file"; then
+        if ! sed "s|<$key[[:space:]]*/>|<$key>$value</$key>|" "$file" > "$TMP_FILE"; then
+            return 1
+        fi
+    else
         return 1
     fi
 


### PR DESCRIPTION
## Summary
- update the network_settings CGI helper to recognise self-closing XML elements and convert them before updating

## Testing
- REQUEST_METHOD=POST CONTENT_LENGTH=${#body} MOBILEAP_CONFIG_PATH=/tmp/test_mobileap_cfg.xml bash -c 'printf "%s" "$0" | www/cgi-bin/network_settings' "$body"


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f63f22d9483278fedf18a8032df9c)