### PR TITLE
Copy updated config data instead of renaming file

### DIFF
--- a/www/cgi-bin/network_settings
+++ b/www/cgi-bin/network_settings
@@ -78,17 +78,24 @@ set_xml_value() {
     local value="$2"
     local file="$3"
 
-    if ! grep -q "<$key>" "$file"; then
+    if grep -q "<$key>" "$file"; then
+        if ! sed "s|<$key>.*</$key>|<$key>$value</$key>|" "$file" > "$TMP_FILE"; then
+            return 1
+        fi
+    elif grep -Eq "<$key[[:space:]]*/>" "$file"; then
+        if ! sed "s|<$key[[:space:]]*/>|<$key>$value</$key>|" "$file" > "$TMP_FILE"; then
+            return 1
+        fi
+    else
         return 1
     fi
 
-    if ! sed "s|<$key>.*</$key>|<$key>$value</$key>|" "$file" > "$TMP_FILE"; then
+    if ! cp "$TMP_FILE" "$file"; then
+        rm -f "$TMP_FILE"
         return 1
     fi
 
-    if ! mv "$TMP_FILE" "$file"; then
-        return 1
-    fi
+    rm -f "$TMP_FILE"
 
     return 0
 }


### PR DESCRIPTION
## Summary
- update the network settings XML write helper to copy the temporary file back to the config instead of renaming it
- clean up the temporary file after a successful copy so repeated saves do not reuse stale data

## Testing
- REQUEST_METHOD=POST CONTENT_LENGTH=${#body} MOBILEAP_CONFIG_PATH=/tmp/test_mobileap_cfg.xml bash -c 'printf "%s" "$0" | ./www/cgi-bin/network_settings' "$body"
- REQUEST_METHOD=POST CONTENT_LENGTH=${#body} MOBILEAP_CONFIG_PATH=/tmp/test_mobileap_cfg_self.xml bash -c 'printf "%s" "$0" | ./www/cgi-bin/network_settings' "$body"

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f63f22d9483278fedf18a8032df9c)