### PR TITLE
Fix user AT command handler to run decoded commands

### DIFF
--- a/www/cgi-bin/user_atcommand
+++ b/www/cgi-bin/user_atcommand
@@ -1,26 +1,76 @@
 #!/bin/bash
-QUERY_STRING=$(echo "${QUERY_STRING}" | sed 's/;//g')
-function urldecode() { : "${*//+/ }"; echo -e "${_//%/\\x}"; }
+set -u
+set -o pipefail
 
-if [ "${QUERY_STRING}" ]; then
-    export IFS="&"
-    for cmd in ${QUERY_STRING}; do
-        if [ "$(echo $cmd | grep '=')" ]; then
-            key=$(echo $cmd | awk -F '=' '{print $1}')
-            value=$(echo $cmd | awk -F '=' '{print $2}')
-            eval $key=$value
+urldecode() {
+    local data="${1//+/ }"
+    printf '%b' "${data//%/\\x}"
+}
+
+strip_ansi() {
+    sed -E 's/\x1B\[[0-9;]*[mG]//g'
+}
+
+print_headers() {
+    printf 'Content-type: text/plain\n\n'
+}
+
+raw_query="${QUERY_STRING:-}"
+clean_query="${raw_query//;/}"
+
+atcmd_param=""
+if [ -n "$clean_query" ]; then
+    IFS='&' read -r -a pairs <<< "$clean_query"
+    for pair in "${pairs[@]}"; do
+        [ -z "$pair" ] && continue
+        key="${pair%%=*}"
+        value=""
+        if [[ "$pair" == *"="* ]]; then
+            value="${pair#*=}"
+        fi
+        if [ "$key" = "atcmd" ]; then
+            atcmd_param="$value"
+            break
         fi
     done
 fi
 
-x=$(urldecode "$atcmd")
-MYATCMD=$(printf '%b\n' "${atcmd//%/\\x}")
-if [ -n "${MYATCMD}" ]; then
-    # Capture the response and remove ANSI color codes using awk
-    runcmd=$(atcli_smd8 '$x' | awk '{ gsub(/\x1B\[[0-9;]*[mG]/, "") }1')
+if [ -z "$atcmd_param" ]; then
+    print_headers
+    printf 'ERROR\n\nMissing atcmd parameter.\n'
+    exit 0
 fi
 
-echo "Content-type: text/plain"
-echo $x
-echo ""
-echo "$runcmd"
+decoded_atcmd="$(urldecode "$atcmd_param")"
+if [ -z "$decoded_atcmd" ]; then
+    print_headers
+    printf 'ERROR\n\nUnable to decode the atcmd parameter.\n'
+    exit 0
+fi
+
+if ! command -v atcli_smd8 >/dev/null 2>&1; then
+    print_headers
+    printf '%s\n\nERROR: atcli_smd8 command not found.\n' "$decoded_atcmd"
+    exit 0
+fi
+
+command_output=""
+exit_code=0
+if ! command_output=$(atcli_smd8 "$decoded_atcmd" 2>&1); then
+    exit_code=$?
+fi
+
+clean_output=$(printf '%s\n' "$command_output" | strip_ansi)
+
+print_headers
+printf '%s\n\n' "$decoded_atcmd"
+
+if [ -n "$clean_output" ]; then
+    printf '%s\n' "$clean_output"
+else
+    if [ $exit_code -ne 0 ]; then
+        printf 'ERROR: atcli_smd8 exited with code %s.\n' "$exit_code"
+    else
+        printf 'ERROR: empty response from modem.\n'
+    fi
+fi


### PR DESCRIPTION
## Summary
- safely parse and decode the atcmd parameter in the user_atcommand CGI script
- execute the decoded command with proper quoting and report failures from atcli_smd8
- strip ANSI color codes from the modem response before returning it to the caller

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f675d04248327951a08627f16d236)