### PR TITLE
Fix network settings save button states

### DIFF
--- a/www/network-settings.html
+++ b/www/network-settings.html
@@ -192,11 +192,15 @@
                       Reset
                     </button>
                     <button type="submit" class="btn btn-primary" :disabled="isSaving">
-                      <span x-show="!isSaving">Save changes</span>
-                      <span x-show="isSaving" class="d-flex align-items-center gap-2">
-                        <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
-                        <span>Saving...</span>
-                      </span>
+                      <template x-if="!isSaving">
+                        <span>Save changes</span>
+                      </template>
+                      <template x-if="isSaving">
+                        <span class="d-flex align-items-center gap-2">
+                          <span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span>
+                          <span>Saving...</span>
+                        </span>
+                      </template>
                     </button>
                   </div>
                 </form>


### PR DESCRIPTION
## Summary
- ensure the network settings Save button only shows one label at a time
- render the idle and saving states conditionally to avoid conflicting Bootstrap display rules

## Testing
- no tests were run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f82e865808327a27453f707939f2f)