### PR TITLE
Ensure DMZ updates persist in MobileAP configuration

### DIFF
--- a/www/cgi-bin/network_settings
+++ b/www/cgi-bin/network_settings
@@ -73,6 +73,40 @@ get_xml_value() {
     echo "$value"
 }
 
+get_scoped_xml_value() {
+    local parent="$1"
+    local key="$2"
+    local file="$3"
+
+    if ! [ -f "$file" ]; then
+        echo ""
+        return
+    fi
+
+    awk -v parent="$parent" -v key="$key" '
+        BEGIN { in_parent = 0 }
+        $0 ~ "<" parent "[[:space:]>]" { in_parent = 1 }
+        {
+            if (in_parent) {
+                if ($0 ~ "<" key "[[:space:]]*/>") {
+                    print ""
+                    exit 0
+                }
+                if ($0 ~ "<" key ">") {
+                    line = $0
+                    gsub(/<!--.*-->/, "", line)
+                    gsub(/\r/, "", line)
+                    sub(".*<" key ">", "", line)
+                    sub("</" key ">.*", "", line)
+                    print line
+                    exit 0
+                }
+            }
+        }
+        $0 ~ "</" parent ">" { if (in_parent) { exit 0 } in_parent = 0 }
+    ' "$file"
+}
+
 set_xml_value() {
     local key="$1"
     local value="$2"
@@ -87,6 +121,45 @@ set_xml_value() {
             return 1
         fi
     else
+        return 1
+    fi
+
+    if ! cp "$TMP_FILE" "$file"; then
+        rm -f "$TMP_FILE"
+        return 1
+    fi
+
+    rm -f "$TMP_FILE"
+
+    return 0
+}
+
+set_scoped_xml_value() {
+    local parent="$1"
+    local key="$2"
+    local value="$3"
+    local file="$4"
+
+    if ! awk -v parent="$parent" -v key="$key" -v value="$value" '
+        BEGIN { in_parent = 0; replaced = 0 }
+        $0 ~ "<" parent "[[:space:]>]" { in_parent = 1 }
+        {
+            if (in_parent) {
+                if ($0 ~ "<" key "[[:space:]]*/>") {
+                    sub("<" key "[[:space:]]*/>", "<" key ">" value "</" key ">");
+                    replaced = 1;
+                } else if ($0 ~ "<" key ">") {
+                    sub("<" key ">[^<]*</" key ">", "<" key ">" value "</" key ">");
+                    replaced = 1;
+                }
+            }
+            if ($0 ~ "</" parent ">" && in_parent) {
+                in_parent = 0;
+            }
+            print
+        }
+        END { exit(replaced ? 0 : 1) }
+    ' "$file" > "$TMP_FILE"; then
         return 1
     fi
 
@@ -268,7 +341,11 @@ handle_get() {
     dhcp_start=$(get_xml_value "StartIP" "$CONFIG_FILE")
     dhcp_end=$(get_xml_value "EndIP" "$CONFIG_FILE")
     dhcp_lease=$(get_xml_value "LeaseTime" "$CONFIG_FILE")
-    dmz_ip=$(get_xml_value "DmzIP" "$CONFIG_FILE")
+    dmz_ip=$(get_scoped_xml_value "MobileAPNatCfg" "DmzIP" "$CONFIG_FILE")
+    if [ -z "$dmz_ip" ]; then
+        dmz_ip=$(get_xml_value "DmzIP" "$CONFIG_FILE")
+    fi
+    dmz_ip=$(printf '%s' "$dmz_ip" | strip_comments | tr -d '\r' | trim)
 
     local dhcp_flag="false"
     if [ "$dhcp_enable" = "1" ]; then
@@ -405,7 +482,7 @@ handle_update() {
         fi
     fi
 
-    if ! set_xml_value "DmzIP" "$dmz_ip" "$CONFIG_FILE"; then
+    if ! set_scoped_xml_value "MobileAPNatCfg" "DmzIP" "$dmz_ip" "$CONFIG_FILE"; then
         respond false "Missing XML element: DmzIP"
     fi
 


### PR DESCRIPTION
## Summary
- add scoped XML helpers to read and write values under a specific parent node
- use the scoped helpers when handling the DMZ IP so the IPv4 entry in MobileAPNatCfg is updated
- normalise the DMZ value returned by the API to avoid stray whitespace

## Testing
- printf '%s' "action=update&ip_address=192.168.225.1&subnet_mask=255.255.255.0&dhcp_enabled=1&dhcp_start=192.168.225.20&dhcp_end=192.168.225.60&dhcp_lease=43200&dmz_enabled=1&dmz_ip=192.168.225.50" | REQUEST_METHOD=POST CONTENT_LENGTH=194 MOBILEAP_CONFIG_PATH=/tmp/mobileap_cfg.xml www/cgi-bin/network_settings
- REQUEST_METHOD=GET QUERY_STRING="action=get" MOBILEAP_CONFIG_PATH=/tmp/mobileap_cfg.xml www/cgi-bin/network_settings

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910929548ec83278c027a82890e6482)