### PR TITLE
Fix login loop by resetting session cache

### DIFF
--- a/www/js/auth.js
+++ b/www/js/auth.js
@@ -51,22 +51,32 @@
   }
 
   function ensureSession({ refresh = false } = {}) {
-    if (!refresh && state.promise) {
-      return state.promise;
+    if (!refresh) {
+      if (state.session) {
+        return Promise.resolve(state.session);
+      }
+
+      if (state.promise) {
+        return state.promise;
+      }
     }
 
-    state.promise = fetchSession().then((session) => {
-      state.session = session;
-      state.loaded = true;
-      callbacks.splice(0).forEach((cb) => {
-        try {
-          cb(session);
-        } catch (error) {
-          console.error("Error running auth callback", error);
-        }
+    state.promise = fetchSession()
+      .then((session) => {
+        state.session = session;
+        state.loaded = true;
+        callbacks.splice(0).forEach((cb) => {
+          try {
+            cb(session);
+          } catch (error) {
+            console.error("Error running auth callback", error);
+          }
+        });
+        return session;
+      })
+      .finally(() => {
+        state.promise = null;
       });
-      return session;
-    });
 
     return state.promise;
   }


### PR DESCRIPTION
## Summary
- avoid reusing an unauthenticated session response after login by caching the resolved session value
- reset the pending session check promise so a new request is made after the first call completes

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c0bdaa8883279c4fdf70eaae8b1f)