### PR TITLE
Rename UI to Simple T99 and update version

### DIFF
--- a/DOCUMENTAZIONE.md
+++ b/DOCUMENTAZIONE.md
@@ -1,7 +1,7 @@
-# Detailed documentation for "Simple Admin"
+# Detailed documentation for "Simple T99"
 
 ## Project overview
-"Simple Admin" is a web administration interface designed for modem/routers based on the Quectel T99W175 modem. The application consists of static HTML pages enhanced with Bootstrap 5 and Alpine.js on the client side, together with a collection of Bash CGI scripts that run AT commands, query the system state, and orchestrate utilities such as Watchcat, TTL override, or SMS sending. Every file is intended to be deployed on the device's web partition and executed by the embedded HTTP server.
+"Simple T99" is a web administration interface designed for modem/routers based on the Quectel T99W175 modem. The application consists of static HTML pages enhanced with Bootstrap 5 and Alpine.js on the client side, together with a collection of Bash CGI scripts that run AT commands, query the system state, and orchestrate utilities such as Watchcat, TTL override, or SMS sending. Every file is intended to be deployed on the device's web partition and executed by the embedded HTTP server.
 
 ## Repository structure
 - `README.md`: brief project overview with a reference to this documentation.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # T99W175-simpleadmin
 
-"Simple Admin" web interface for the T99W175 modem/router, composed of static HTML/JS pages and Bash CGI scripts that interact with the device's networking services. For a detailed description of each file and the available features, see [DOCUMENTAZIONE.md](DOCUMENTAZIONE.md).
+"Simple T99" web interface for the T99W175 modem/router, composed of static HTML/JS pages and Bash CGI scripts that interact with the device's networking services. For a detailed description of each file and the available features, see [DOCUMENTAZIONE.md](DOCUMENTAZIONE.md).

--- a/www/credentials.html
+++ b/www/credentials.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Simple Admin &mdash; Gestione Credenziali</title>
+    <title>Simple T99 &mdash; Gestione Credenziali</title>
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
     <link rel="icon" href="favicon.ico" />
@@ -18,7 +18,7 @@
         <nav class="navbar navbar-expand-lg mt-2">
           <div class="container-fluid">
             <a class="navbar-brand" href="/"
-              ><span class="mb-0 h4">Simple Admin</span></a
+              ><span class="mb-0 h4">Simple T99</span></a
             >
             <button
               class="navbar-toggler"

--- a/www/deviceinfo.html
+++ b/www/deviceinfo.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Simple Admin</title>
+    <title>Simple T99</title>
     <!-- Import all the bootstrap css files from css folder -->
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
@@ -19,7 +19,7 @@
         <nav class="navbar navbar-expand-lg mt-2">
           <div class="container-fluid">
             <a class="navbar-brand" href="/"
-              ><span class="mb-0 h4">Simple Admin</span></a
+              ><span class="mb-0 h4">Simple T99</span></a
             >
             <button
               class="navbar-toggler"
@@ -142,7 +142,7 @@
       <td class="col-md-2" x-text="wwanIpv6"></td>
     </tr>
     <tr>
-      <th scope="row">Simple Admin Version</th>
+      <th scope="row">Simple T99 Version</th>
       <td class="col-md-2" x-text="simpleAdminVersion"></td>
     </tr>
   </tbody>
@@ -440,7 +440,7 @@
     this.wwanIpv4 = wwanIpv4 || "-";
     this.wwanIpv6 = wwanIpv6 || "-";
     // Define the GUI version here
-    this.simpleAdminVersion = "T99-BETA011";
+    this.simpleAdminVersion = "T99-RC01";
     this.showError = false;
   } catch (error) {
     console.error("Parsing error:", error);

--- a/www/index.html
+++ b/www/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Simple Admin</title>
+    <title>Simple T99</title>
     <!-- Import all the bootstrap css files from css folder -->
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
@@ -22,7 +22,7 @@
         <nav class="navbar navbar-expand-lg mt-2">
           <div class="container-fluid">
             <a class="navbar-brand" href="/"
-              ><span class="mb-0 h4">Simple Admin</span></a
+              ><span class="mb-0 h4">Simple T99</span></a
             >
             <button
               class="navbar-toggler"

--- a/www/login.html
+++ b/www/login.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Simple Admin &mdash; Login</title>
+    <title>Simple T99 &mdash; Login</title>
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
     <link rel="icon" href="favicon.ico" />
@@ -18,7 +18,7 @@
         <nav class="navbar navbar-expand-lg mt-2">
           <div class="container-fluid">
             <a class="navbar-brand" href="/login.html"
-              ><span class="mb-0 h4">Simple Admin</span></a
+              ><span class="mb-0 h4">Simple T99</span></a
             >
             <div class="d-flex align-items-center ms-auto">
               <button
@@ -37,7 +37,7 @@
           <div class="col-lg-5 col-md-7">
             <div class="card shadow-sm">
               <div class="card-header text-center">
-                <h5 class="mb-0">Accedi a Simple Admin</h5>
+                <h5 class="mb-0">Accedi a Simple T99</h5>
               </div>
               <div class="card-body">
                 <div

--- a/www/network-settings.html
+++ b/www/network-settings.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Simple Admin</title>
+    <title>Simple T99</title>
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
     <link rel="simpleadmin-logo" href="favicon.ico" />
@@ -17,7 +17,7 @@
         <nav class="navbar navbar-expand-lg mt-2">
           <div class="container-fluid">
             <a class="navbar-brand" href="/"
-              ><span class="mb-0 h4">Simple Admin</span></a
+              ><span class="mb-0 h4">Simple T99</span></a
             >
             <button
               class="navbar-toggler"

--- a/www/network.html
+++ b/www/network.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Simple Admin</title>
+    <title>Simple T99</title>
     <!-- Import all the bootstrap css files from css folder -->
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
@@ -22,7 +22,7 @@
         <nav class="navbar navbar-expand-lg mt-2">
           <div class="container-fluid">
             <a class="navbar-brand" href="/"
-              ><span class="mb-0 h4">Simple Admin</span></a
+              ><span class="mb-0 h4">Simple T99</span></a
             >
             <button
               class="navbar-toggler"

--- a/www/scanner.html
+++ b/www/scanner.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Simple Admin</title>
+    <title>Simple T99</title>
     <!-- Import all the bootstrap css files from css folder -->
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
@@ -24,7 +24,7 @@
         <nav class="navbar navbar-expand-lg mt-2">
           <div class="container-fluid">
             <a class="navbar-brand" href="/"
-              ><span class="mb-0 h4">Simple Admin</span></a
+              ><span class="mb-0 h4">Simple T99</span></a
             >
             <button
               class="navbar-toggler"

--- a/www/settings.html
+++ b/www/settings.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Simple Admin</title>
+    <title>Simple T99</title>
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
 
@@ -21,7 +21,7 @@
         <nav class="navbar navbar-expand-lg mt-2">
           <div class="container-fluid">
             <a class="navbar-brand" href="/"
-              ><span class="mb-0 h4">Simple Admin</span></a
+              ><span class="mb-0 h4">Simple T99</span></a
             >
             <button
               class="navbar-toggler"

--- a/www/sms.html
+++ b/www/sms.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Simple Admin</title>
+  <title>Simple T99</title>
   
   <link rel="stylesheet" href="css/styles.css" />
   <link rel="stylesheet" href="css/bootstrap.min.css" />
@@ -23,7 +23,7 @@
     <div class="container my-4" x-data="fetchSMS()">
       <nav class="navbar navbar-expand-lg mt-2">
         <div class="container-fluid">
-          <a class="navbar-brand" href="/"><span class="mb-0 h4">Simple Admin</span></a>
+          <a class="navbar-brand" href="/"><span class="mb-0 h4">Simple T99</span></a>
           <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarText"
             aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation" data-allow-user="true">
             <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
## Summary
- rename the interface branding from Simple Admin to Simple T99 across documentation and UI pages
- update the displayed version label in the device info page to T99-RC01

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c5f3294c8327a240306ae6811230)