### PR TITLE
Move credential management link and theme toggle to footer

### DIFF
--- a/www/credentials.html
+++ b/www/credentials.html
@@ -52,11 +52,6 @@
                 <li class="nav-item">
                   <a class="nav-link" href="/deviceinfo.html">Device Information</a>
                 </li>
-                <li class="nav-item">
-                  <a class="nav-link active" aria-current="page" href="/credentials.html"
-                    >Gestione Credenziali</a
-                  >
-                </li>
               </ul>
               <div
                 class="navbar-text d-flex align-items-center gap-3 flex-wrap justify-content-end"
@@ -72,14 +67,6 @@
                   type="button"
                 >
                   Logout
-                </button>
-                <button
-                  class="btn btn-link text-reset"
-                  id="darkModeToggle"
-                  type="button"
-                  data-allow-user="true"
-                >
-                  Dark Mode
                 </button>
               </div>
             </div>
@@ -224,6 +211,26 @@
         </div>
       </div>
     </main>
+    <footer class="border-top py-3 mt-4">
+      <div
+        class="container d-flex flex-wrap gap-3 justify-content-between align-items-center"
+      >
+        <a
+          class="btn btn-outline-secondary btn-sm"
+          href="/credentials.html"
+        >
+          Gestione Credenziali
+        </a>
+        <button
+          class="btn btn-link text-reset"
+          id="darkModeToggle"
+          type="button"
+          data-allow-user="true"
+        >
+          Dark Mode
+        </button>
+      </div>
+    </footer>
     <script src="js/dark-mode.js"></script>
   </body>
 </html>

--- a/www/deviceinfo.html
+++ b/www/deviceinfo.html
@@ -58,11 +58,6 @@
                     >Device Information</a
                   >
                 </li>
-                <li class="nav-item" data-requires-admin="hide">
-                  <a class="nav-link" href="/credentials.html"
-                    >Gestione Credenziali</a
-                  >
-                </li>
               </ul>
               <div
                 class="navbar-text d-flex align-items-center gap-3 flex-wrap justify-content-end"
@@ -78,14 +73,6 @@
                   type="button"
                 >
                   Logout
-                </button>
-                <button
-                  class="btn btn-link text-reset"
-                  id="darkModeToggle"
-                  type="button"
-                  data-allow-user="true"
-                >
-                  Dark Mode
                 </button>
               </div>
             </div>
@@ -220,6 +207,27 @@
         </div>
       </div>
     </main>
+    <footer class="border-top py-3 mt-4">
+      <div
+        class="container d-flex flex-wrap gap-3 justify-content-between align-items-center"
+      >
+        <a
+          class="btn btn-outline-secondary btn-sm"
+          href="/credentials.html"
+          data-requires-admin="hide"
+        >
+          Gestione Credenziali
+        </a>
+        <button
+          class="btn btn-link text-reset"
+          id="darkModeToggle"
+          type="button"
+          data-allow-user="true"
+        >
+          Dark Mode
+        </button>
+      </div>
+    </footer>
     <script src="js/atcommand-utils.js"></script>
     <script src="js/dark-mode.js"></script>
     <script>

--- a/www/index.html
+++ b/www/index.html
@@ -60,11 +60,6 @@
                     >Device Information</a
                   >
                 </li>
-                <li class="nav-item" data-requires-admin="hide">
-                  <a class="nav-link" href="/credentials.html"
-                    >Gestione Credenziali</a
-                  >
-                </li>
               </ul>
               <div
                 class="navbar-text d-flex align-items-center gap-3 flex-wrap justify-content-end"
@@ -80,14 +75,6 @@
                   type="button"
                 >
                   Logout
-                </button>
-                <button
-                  class="btn btn-link text-reset"
-                  id="darkModeToggle"
-                  type="button"
-                  data-allow-user="true"
-                >
-                  Dark Mode
                 </button>
               </div>
             </div>
@@ -821,6 +808,27 @@
         </div>
       </div>
     </main>
+    <footer class="border-top py-3 mt-4">
+      <div
+        class="container d-flex flex-wrap gap-3 justify-content-between align-items-center"
+      >
+        <a
+          class="btn btn-outline-secondary btn-sm"
+          href="/credentials.html"
+          data-requires-admin="hide"
+        >
+          Gestione Credenziali
+        </a>
+        <button
+          class="btn btn-link text-reset"
+          id="darkModeToggle"
+          type="button"
+          data-allow-user="true"
+        >
+          Dark Mode
+        </button>
+      </div>
+    </footer>
     <script src="js/atcommand-utils.js"></script>
     <script src="js/dark-mode.js"></script>
 

--- a/www/login.html
+++ b/www/login.html
@@ -20,16 +20,6 @@
             <a class="navbar-brand" href="/login.html"
               ><span class="mb-0 h4">Simple T99</span></a
             >
-            <div class="d-flex align-items-center ms-auto">
-              <button
-                class="btn btn-link text-reset"
-                id="darkModeToggle"
-                type="button"
-                data-allow-user="true"
-              >
-                Dark Mode
-              </button>
-            </div>
           </div>
         </nav>
 
@@ -90,6 +80,18 @@
         </div>
       </div>
     </main>
+    <footer class="border-top py-3 mt-4">
+      <div class="container d-flex justify-content-end">
+        <button
+          class="btn btn-link text-reset"
+          id="darkModeToggle"
+          type="button"
+          data-allow-user="true"
+        >
+          Dark Mode
+        </button>
+      </div>
+    </footer>
     <script src="js/dark-mode.js"></script>
   </body>
 </html>

--- a/www/network-settings.html
+++ b/www/network-settings.html
@@ -53,11 +53,6 @@
                 <li class="nav-item">
                   <a class="nav-link" href="/deviceinfo.html">Device Information</a>
                 </li>
-                <li class="nav-item" data-requires-admin="hide">
-                  <a class="nav-link" href="/credentials.html"
-                    >Gestione Credenziali</a
-                  >
-                </li>
               </ul>
               <div
                 class="navbar-text d-flex align-items-center gap-3 flex-wrap justify-content-end"
@@ -73,14 +68,6 @@
                   type="button"
                 >
                   Logout
-                </button>
-                <button
-                  class="btn btn-link text-reset"
-                  id="darkModeToggle"
-                  type="button"
-                  data-allow-user="true"
-                >
-                  Dark Mode
                 </button>
               </div>
             </div>
@@ -325,6 +312,27 @@
         </div>
       </div>
     </main>
+    <footer class="border-top py-3 mt-4">
+      <div
+        class="container d-flex flex-wrap gap-3 justify-content-between align-items-center"
+      >
+        <a
+          class="btn btn-outline-secondary btn-sm"
+          href="/credentials.html"
+          data-requires-admin="hide"
+        >
+          Gestione Credenziali
+        </a>
+        <button
+          class="btn btn-link text-reset"
+          id="darkModeToggle"
+          type="button"
+          data-allow-user="true"
+        >
+          Dark Mode
+        </button>
+      </div>
+    </footer>
 
     <script>
       document.addEventListener("alpine:init", () => {

--- a/www/network.html
+++ b/www/network.html
@@ -65,11 +65,6 @@
                     >Device Information</a
                   >
                 </li>
-                <li class="nav-item" data-requires-admin="hide">
-                  <a class="nav-link" href="/credentials.html"
-                    >Gestione Credenziali</a
-                  >
-                </li>
               </ul>
               <div
                 class="navbar-text d-flex align-items-center gap-3 flex-wrap justify-content-end"
@@ -85,14 +80,6 @@
                   type="button"
                 >
                   Logout
-                </button>
-                <button
-                  class="btn btn-link text-reset"
-                  id="darkModeToggle"
-                  type="button"
-                  data-allow-user="true"
-                >
-                  Dark Mode
                 </button>
               </div>
             </div>
@@ -499,6 +486,27 @@
         </div>
       </div>
     </main>
+    <footer class="border-top py-3 mt-4">
+      <div
+        class="container d-flex flex-wrap gap-3 justify-content-between align-items-center"
+      >
+        <a
+          class="btn btn-outline-secondary btn-sm"
+          href="/credentials.html"
+          data-requires-admin="hide"
+        >
+          Gestione Credenziali
+        </a>
+        <button
+          class="btn btn-link text-reset"
+          id="darkModeToggle"
+          type="button"
+          data-allow-user="true"
+        >
+          Dark Mode
+        </button>
+      </div>
+    </footer>
 
     <script src="js/generate-freq-box.js"></script>
     <script src="js/populate-checkbox.js"></script>

--- a/www/scanner.html
+++ b/www/scanner.html
@@ -60,11 +60,6 @@
                     >Device Information</a
                   >
                 </li>
-                <li class="nav-item" data-requires-admin="hide">
-                  <a class="nav-link" href="/credentials.html"
-                    >Gestione Credenziali</a
-                  >
-                </li>
               </ul>
               <div
                 class="navbar-text d-flex align-items-center gap-3 flex-wrap justify-content-end"
@@ -80,14 +75,6 @@
                   type="button"
                 >
                   Logout
-                </button>
-                <button
-                  class="btn btn-link text-reset"
-                  id="darkModeToggle"
-                  type="button"
-                  data-allow-user="true"
-                >
-                  Dark Mode
                 </button>
               </div>
             </div>
@@ -244,6 +231,27 @@
         </div>
       </div>
     </main>
+    <footer class="border-top py-3 mt-4">
+      <div
+        class="container d-flex flex-wrap gap-3 justify-content-between align-items-center"
+      >
+        <a
+          class="btn btn-outline-secondary btn-sm"
+          href="/credentials.html"
+          data-requires-admin="hide"
+        >
+          Gestione Credenziali
+        </a>
+        <button
+          class="btn btn-link text-reset"
+          id="darkModeToggle"
+          type="button"
+          data-allow-user="true"
+        >
+          Dark Mode
+        </button>
+      </div>
+    </footer>
     <script src="js/atcommand-utils.js"></script>
     <script src="js/dark-mode.js"></script>
     <script>

--- a/www/settings.html
+++ b/www/settings.html
@@ -62,11 +62,6 @@
                     >Device Information</a
                   >
                 </li>
-                <li class="nav-item" data-requires-admin="hide">
-                  <a class="nav-link" href="/credentials.html"
-                    >Gestione Credenziali</a
-                  >
-                </li>
               </ul>
               <div
                 class="navbar-text d-flex align-items-center gap-3 flex-wrap justify-content-end"
@@ -82,14 +77,6 @@
                   type="button"
                 >
                   Logout
-                </button>
-                <button
-                  class="btn btn-link text-reset"
-                  id="darkModeToggle"
-                  type="button"
-                  data-allow-user="true"
-                >
-                  Dark Mode
                 </button>
               </div>
             </div>
@@ -307,6 +294,27 @@
         </div>
       </div>
     </main>
+    <footer class="border-top py-3 mt-4">
+      <div
+        class="container d-flex flex-wrap gap-3 justify-content-between align-items-center"
+      >
+        <a
+          class="btn btn-outline-secondary btn-sm"
+          href="/credentials.html"
+          data-requires-admin="hide"
+        >
+          Gestione Credenziali
+        </a>
+        <button
+          class="btn btn-link text-reset"
+          id="darkModeToggle"
+          type="button"
+          data-allow-user="true"
+        >
+          Dark Mode
+        </button>
+      </div>
+    </footer>
     <script src="js/atcommand-utils.js"></script>
     <script src="js/dark-mode.js"></script>
     <script>

--- a/www/sms.html
+++ b/www/sms.html
@@ -49,18 +49,12 @@
               <li class="nav-item">
                 <a class="nav-link" href="/deviceinfo.html">Device Information</a>
               </li>
-              <li class="nav-item" data-requires-admin="hide">
-                <a class="nav-link" href="/credentials.html">Gestione Credenziali</a>
-              </li>
             </ul>
             <div class="navbar-text d-flex align-items-center gap-3 flex-wrap justify-content-end">
               <span class="badge rounded-pill fw-semibold text-uppercase d-none" id="navUserRole"></span>
               <span class="fw-semibold" id="navUserName"></span>
               <button class="btn btn-outline-secondary btn-sm" id="logoutButton" type="button">
                 Logout
-              </button>
-              <button class="btn btn-link text-reset" id="darkModeToggle" type="button" data-allow-user="true">
-                Dark Mode
               </button>
             </div>
           </div>
@@ -169,6 +163,16 @@
       </div>
     </div>
   </main>
+  <footer class="border-top py-3 mt-4">
+    <div class="container d-flex flex-wrap gap-3 justify-content-between align-items-center">
+      <a class="btn btn-outline-secondary btn-sm" href="/credentials.html" data-requires-admin="hide">
+        Gestione Credenziali
+      </a>
+      <button class="btn btn-link text-reset" id="darkModeToggle" type="button" data-allow-user="true">
+        Dark Mode
+      </button>
+    </div>
+  </footer>
     <script src="js/atcommand-utils.js"></script>
     <script src="js/dark-mode.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- move the Gestione Credenziali navigation link from the top bar into a new footer section across the authenticated pages
- relocate the dark/light mode toggle into the footer to sit alongside the credential management control
- add the same footer treatment to the login screen so the theme toggle lives in a consistent place

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910c9a2ac848327990407db92078eb9)