### PR TITLE
Translate Italian UI strings to English

### DIFF
--- a/www/config/simpleadmin.conf
+++ b/www/config/simpleadmin.conf
@@ -1,4 +1,4 @@
-# Configurazione di SimpleAdmin
-# Imposta a 0 per disabilitare completamente il login e consentire l'accesso libero.
-# Imposta a 1 (valore predefinito) per richiedere il login degli utenti.
+# SimpleAdmin configuration
+# Set to 0 to completely disable login and allow open access.
+# Set to 1 (default) to require user login.
 SIMPLEADMIN_ENABLE_LOGIN=1

--- a/www/credentials.html
+++ b/www/credentials.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Simple T99 &mdash; Gestione Credenziali</title>
+    <title>Simple T99 &mdash; Credential Management</title>
     <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/bootstrap.min.css" />
     <link rel="icon" href="favicon.ico" />
@@ -77,8 +77,8 @@
           <div class="col-lg-8">
             <div class="card">
               <div class="card-header d-flex justify-content-between align-items-center">
-                <span>Utenti registrati</span>
-                <span class="badge text-bg-info">Solo Admin</span>
+                <span>Registered users</span>
+                <span class="badge text-bg-info">Admin Only</span>
               </div>
               <div class="card-body">
                 <div
@@ -91,13 +91,13 @@
                     <thead>
                       <tr>
                         <th scope="col">Username</th>
-                        <th scope="col">Ruolo</th>
+                        <th scope="col">Role</th>
                       </tr>
                     </thead>
                     <tbody id="usersTableBody">
                       <tr>
                         <td colspan="2" class="text-center text-body-secondary">
-                          Caricamento utenti...
+                          Loading users...
                         </td>
                       </tr>
                     </tbody>
@@ -108,7 +108,7 @@
           </div>
           <div class="col-lg-4">
             <div class="card mb-4">
-              <div class="card-header">Aggiungi nuovo utente</div>
+              <div class="card-header">Add new user</div>
               <div class="card-body">
                 <form id="addUserForm" autocomplete="off">
                   <div class="mb-3">
@@ -119,7 +119,7 @@
                       id="newUsername"
                       name="username"
                       required
-                      placeholder="es. admin2"
+                      placeholder="e.g. admin2"
                     />
                   </div>
                   <div class="mb-3">
@@ -133,29 +133,29 @@
                     />
                   </div>
                   <div class="mb-3">
-                    <label for="newRole" class="form-label">Ruolo</label>
+                    <label for="newRole" class="form-label">Role</label>
                     <select class="form-select" id="newRole" name="role">
-                      <option value="user" selected>Utente (Sola lettura)</option>
+                      <option value="user" selected>User (Read-only)</option>
                       <option value="admin">Admin</option>
                     </select>
                   </div>
                   <button type="submit" class="btn btn-primary w-100">
-                    Crea utente
+                    Create user
                   </button>
                 </form>
               </div>
             </div>
             <div class="card mb-4">
-              <div class="card-header">Aggiorna password</div>
+              <div class="card-header">Update password</div>
               <div class="card-body">
                 <form id="updatePasswordForm" autocomplete="off">
                   <div class="mb-3">
-                    <label for="passwordUserSelect" class="form-label">Utente</label>
+                    <label for="passwordUserSelect" class="form-label">User</label>
                     <select class="form-select" id="passwordUserSelect" name="username">
                     </select>
                   </div>
                   <div class="mb-3">
-                    <label for="passwordNewValue" class="form-label">Nuova password</label>
+                    <label for="passwordNewValue" class="form-label">New password</label>
                     <input
                       type="password"
                       class="form-control"
@@ -165,44 +165,44 @@
                     />
                   </div>
                   <button type="submit" class="btn btn-primary w-100">
-                    Aggiorna password
+                    Update password
                   </button>
                 </form>
               </div>
             </div>
             <div class="card mb-4">
-              <div class="card-header">Modifica ruolo</div>
+              <div class="card-header">Change role</div>
               <div class="card-body">
                 <form id="updateRoleForm">
                   <div class="mb-3">
-                    <label for="roleUserSelect" class="form-label">Utente</label>
+                    <label for="roleUserSelect" class="form-label">User</label>
                     <select class="form-select" id="roleUserSelect" name="username">
                     </select>
                   </div>
                   <div class="mb-3">
-                    <label for="roleNewValue" class="form-label">Nuovo ruolo</label>
+                    <label for="roleNewValue" class="form-label">New role</label>
                     <select class="form-select" id="roleNewValue" name="role">
-                      <option value="user">Utente (Sola lettura)</option>
+                      <option value="user">User (Read-only)</option>
                       <option value="admin">Admin</option>
                     </select>
                   </div>
                   <button type="submit" class="btn btn-primary w-100">
-                    Aggiorna ruolo
+                    Update role
                   </button>
                 </form>
               </div>
             </div>
             <div class="card">
-              <div class="card-header">Elimina utente</div>
+              <div class="card-header">Delete user</div>
               <div class="card-body">
                 <form id="deleteUserForm">
                   <div class="mb-3">
-                    <label for="deleteUserSelect" class="form-label">Utente</label>
+                    <label for="deleteUserSelect" class="form-label">User</label>
                     <select class="form-select" id="deleteUserSelect" name="username">
                     </select>
                   </div>
                   <button type="submit" class="btn btn-danger w-100">
-                    Elimina utente
+                    Delete user
                   </button>
                 </form>
               </div>
@@ -219,7 +219,7 @@
           class="btn btn-outline-secondary btn-sm"
           href="/credentials.html"
         >
-          Gestione Credenziali
+          Credential Management
         </a>
         <button
           class="btn btn-link text-reset"

--- a/www/deviceinfo.html
+++ b/www/deviceinfo.html
@@ -216,7 +216,7 @@
           href="/credentials.html"
           data-requires-admin="hide"
         >
-          Gestione Credenziali
+          Credential Management
         </a>
         <button
           class="btn btn-link text-reset"

--- a/www/index.html
+++ b/www/index.html
@@ -817,7 +817,7 @@
           href="/credentials.html"
           data-requires-admin="hide"
         >
-          Gestione Credenziali
+          Credential Management
         </a>
         <button
           class="btn btn-link text-reset"

--- a/www/js/credentials.js
+++ b/www/js/credentials.js
@@ -64,7 +64,7 @@
     }
 
     if (!Array.isArray(users) || users.length === 0) {
-      tbody.innerHTML = '<tr><td colspan="2" class="text-center">Nessun utente configurato.</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="2" class="text-center">No users configured.</td></tr>';
       return;
     }
 
@@ -94,7 +94,7 @@
 
       const payload = await response.json();
       if (!payload.success || !Array.isArray(payload.data)) {
-        throw new Error("Formato risposta non valido");
+        throw new Error("Invalid response format");
       }
 
       updateTable(payload.data);
@@ -102,8 +102,8 @@
       populateSelect(selectors.roleUserSelect, payload.data);
       populateSelect(selectors.deleteUserSelect, payload.data);
     } catch (error) {
-      console.error("Impossibile caricare gli utenti", error);
-      showFeedback("Errore durante il caricamento degli utenti.", "danger");
+      console.error("Unable to load users", error);
+      showFeedback("Error loading users.", "danger");
     }
   }
 
@@ -132,7 +132,7 @@
 
       const payload = await response.json().catch(() => ({ success: false }));
       if (!response.ok || !payload.success) {
-        showFeedback(payload.message || "Operazione non riuscita.", "danger");
+        showFeedback(payload.message || "Operation failed.", "danger");
         return;
       }
 
@@ -140,8 +140,8 @@
       form.reset();
       await loadUsers();
     } catch (error) {
-      console.error("Operazione credenziali fallita", error);
-      showFeedback("Errore durante l'operazione richiesta.", "danger");
+      console.error("Credential operation failed", error);
+      showFeedback("Error during the requested operation.", "danger");
     } finally {
       if (submitButton) {
         submitButton.disabled = false;
@@ -164,28 +164,28 @@
       const addForm = document.getElementById(selectors.addForm);
       if (addForm) {
         addForm.addEventListener("submit", (event) =>
-          submitForm(event, "add", "Utente aggiunto correttamente.")
+          submitForm(event, "add", "User added successfully.")
         );
       }
 
       const updatePasswordForm = document.getElementById(selectors.updatePasswordForm);
       if (updatePasswordForm) {
         updatePasswordForm.addEventListener("submit", (event) =>
-          submitForm(event, "update_password", "Password aggiornata.")
+          submitForm(event, "update_password", "Password updated.")
         );
       }
 
       const updateRoleForm = document.getElementById(selectors.updateRoleForm);
       if (updateRoleForm) {
         updateRoleForm.addEventListener("submit", (event) =>
-          submitForm(event, "update_role", "Ruolo aggiornato.")
+          submitForm(event, "update_role", "Role updated.")
         );
       }
 
       const deleteForm = document.getElementById(selectors.deleteForm);
       if (deleteForm) {
         deleteForm.addEventListener("submit", (event) =>
-          submitForm(event, "delete", "Utente eliminato.")
+          submitForm(event, "delete", "User removed.")
         );
       }
     });

--- a/www/js/login.js
+++ b/www/js/login.js
@@ -35,7 +35,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const password = formData.get("password");
 
     if (!username || !password) {
-      showAlert("Inserire username e password.");
+      showAlert("Enter username and password.");
       return;
     }
 
@@ -56,14 +56,14 @@ document.addEventListener("DOMContentLoaded", () => {
       const payload = await response.json().catch(() => ({ success: false }));
 
       if (!response.ok || !payload.success) {
-        showAlert(payload.message || "Credenziali non valide.");
+        showAlert(payload.message || "Invalid credentials.");
         return;
       }
 
       window.location.replace("/index.html");
     } catch (error) {
       console.error("Login failed", error);
-      showAlert("Errore durante l'autenticazione.");
+      showAlert("Error during authentication.");
     } finally {
       if (submitButton) {
         submitButton.disabled = false;

--- a/www/login.html
+++ b/www/login.html
@@ -27,7 +27,7 @@
           <div class="col-lg-5 col-md-7">
             <div class="card shadow-sm">
               <div class="card-header text-center">
-                <h5 class="mb-0">Accedi a Simple T99</h5>
+                <h5 class="mb-0">Sign in to Simple T99</h5>
               </div>
               <div class="card-body">
                 <div
@@ -43,7 +43,7 @@
                       class="form-control"
                       id="username"
                       name="username"
-                      placeholder="Inserisci username"
+                        placeholder="Enter username"
                       required
                     />
                   </div>
@@ -54,7 +54,7 @@
                       class="form-control"
                       id="password"
                       name="password"
-                      placeholder="Inserisci password"
+                        placeholder="Enter password"
                       required
                     />
                   </div>
@@ -64,15 +64,15 @@
                       class="btn btn-primary"
                       id="loginSubmit"
                     >
-                      Accedi
+                      Sign In
                     </button>
                   </div>
                 </form>
               </div>
               <div class="card-footer text-body-secondary text-center">
                 <small>
-                  Accesso riservato agli utenti autorizzati. Contatta un
-                  amministratore per ottenere le credenziali.
+                  Access restricted to authorized users. Contact an
+                  administrator to obtain credentials.
                 </small>
               </div>
             </div>

--- a/www/network-settings.html
+++ b/www/network-settings.html
@@ -321,7 +321,7 @@
           href="/credentials.html"
           data-requires-admin="hide"
         >
-          Gestione Credenziali
+          Credential Management
         </a>
         <button
           class="btn btn-link text-reset"

--- a/www/network.html
+++ b/www/network.html
@@ -495,7 +495,7 @@
           href="/credentials.html"
           data-requires-admin="hide"
         >
-          Gestione Credenziali
+          Credential Management
         </a>
         <button
           class="btn btn-link text-reset"

--- a/www/scanner.html
+++ b/www/scanner.html
@@ -240,7 +240,7 @@
           href="/credentials.html"
           data-requires-admin="hide"
         >
-          Gestione Credenziali
+          Credential Management
         </a>
         <button
           class="btn btn-link text-reset"

--- a/www/settings.html
+++ b/www/settings.html
@@ -303,7 +303,7 @@
           href="/credentials.html"
           data-requires-admin="hide"
         >
-          Gestione Credenziali
+          Credential Management
         </a>
         <button
           class="btn btn-link text-reset"

--- a/www/sms.html
+++ b/www/sms.html
@@ -166,7 +166,7 @@
   <footer class="border-top py-3 mt-4">
     <div class="container d-flex flex-wrap gap-3 justify-content-between align-items-center">
       <a class="btn btn-outline-secondary btn-sm" href="/credentials.html" data-requires-admin="hide">
-        Gestione Credenziali
+        Credential Management
       </a>
       <button class="btn btn-link text-reset" id="darkModeToggle" type="button" data-allow-user="true">
         Dark Mode


### PR DESCRIPTION
## Summary
- replace the Italian copy on the login and credential management screens with English text
- translate credential management JavaScript feedback messages to English
- update footer navigation labels and configuration comments to English wording

## Testing
- not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910d069ee548327b10df993d6015df0)