### PR TITLE
Update remote configuration UI for RouterOS LTE

### DIFF
--- a/remote_admin_backend/config.py
+++ b/remote_admin_backend/config.py
@@ -13,8 +13,6 @@ _DEFAULT_CONFIG = {
     "username": "",
     "password": "",
     "interface": "",
-    "at_command_tool": "atcli_smd8",
-    "at_command_args": "",
 }
 
 _LOCK = threading.RLock()

--- a/www/index.html
+++ b/www/index.html
@@ -863,38 +863,19 @@
               </div>
               <div class="col-12">
                 <label class="form-label" for="remoteInterface"
-                  >AT interface</label
+                  >LTE interface name</label
                 >
                 <input
                   type="text"
                   class="form-control"
                   id="remoteInterface"
                   name="interface"
-                  placeholder="/dev/ttyUSB2"
+                  placeholder="lte1"
                 />
-              </div>
-              <div class="col-12">
-                <label class="form-label" for="remoteTool"
-                  >AT command tool</label
-                >
-                <input
-                  type="text"
-                  class="form-control"
-                  id="remoteTool"
-                  name="at_command_tool"
-                  value="atcli_smd8"
-                />
-              </div>
-              <div class="col-12">
-                <label class="form-label" for="remoteArgs"
-                  >Additional tool arguments</label
-                >
-                <input
-                  type="text"
-                  class="form-control"
-                  id="remoteArgs"
-                  name="at_command_args"
-                />
+                <div class="form-text">
+                  Use the RouterOS LTE interface that exposes the modem (for example
+                  <code>lte1</code>).
+                </div>
               </div>
             </div>
             <div class="mt-3" data-remote-config-status></div>

--- a/www/js/remote-config.js
+++ b/www/js/remote-config.js
@@ -15,8 +15,6 @@
     username: form.querySelector("[name=username]"),
     password: form.querySelector("[name=password]"),
     interface: form.querySelector("[name=interface]"),
-    at_command_tool: form.querySelector("[name=at_command_tool]"),
-    at_command_args: form.querySelector("[name=at_command_args]"),
   };
 
   function setStatus(message, type = "") {

--- a/www/network.html
+++ b/www/network.html
@@ -516,38 +516,19 @@
               </div>
               <div class="col-12">
                 <label class="form-label" for="remoteInterface"
-                  >AT interface</label
+                  >LTE interface name</label
                 >
                 <input
                   type="text"
                   class="form-control"
                   id="remoteInterface"
                   name="interface"
-                  placeholder="/dev/ttyUSB2"
+                  placeholder="lte1"
                 />
-              </div>
-              <div class="col-12">
-                <label class="form-label" for="remoteTool"
-                  >AT command tool</label
-                >
-                <input
-                  type="text"
-                  class="form-control"
-                  id="remoteTool"
-                  name="at_command_tool"
-                  value="atcli_smd8"
-                />
-              </div>
-              <div class="col-12">
-                <label class="form-label" for="remoteArgs"
-                  >Additional tool arguments</label
-                >
-                <input
-                  type="text"
-                  class="form-control"
-                  id="remoteArgs"
-                  name="at_command_args"
-                />
+                <div class="form-text">
+                  Use the RouterOS LTE interface that exposes the modem (for example
+                  <code>lte1</code>).
+                </div>
               </div>
             </div>
             <div class="mt-3" data-remote-config-status></div>

--- a/www/settings.html
+++ b/www/settings.html
@@ -351,38 +351,19 @@
               </div>
               <div class="col-12">
                 <label class="form-label" for="remoteInterface"
-                  >AT interface</label
+                  >LTE interface name</label
                 >
                 <input
                   type="text"
                   class="form-control"
                   id="remoteInterface"
                   name="interface"
-                  placeholder="/dev/ttyUSB2"
+                  placeholder="lte1"
                 />
-              </div>
-              <div class="col-12">
-                <label class="form-label" for="remoteTool"
-                  >AT command tool</label
-                >
-                <input
-                  type="text"
-                  class="form-control"
-                  id="remoteTool"
-                  name="at_command_tool"
-                  value="atcli_smd8"
-                />
-              </div>
-              <div class="col-12">
-                <label class="form-label" for="remoteArgs"
-                  >Additional tool arguments</label
-                >
-                <input
-                  type="text"
-                  class="form-control"
-                  id="remoteArgs"
-                  name="at_command_args"
-                />
+                <div class="form-text">
+                  Use the RouterOS LTE interface that exposes the modem (for example
+                  <code>lte1</code>).
+                </div>
               </div>
             </div>
             <div class="mt-3" data-remote-config-status></div>


### PR DESCRIPTION
## Summary
- remove legacy AT command tool configuration options from the remote backend defaults
- update the remote configuration modal to collect the RouterOS LTE interface name with inline guidance
- align the remote configuration client script with the simplified backend configuration

## Testing
- python -m compileall remote_admin_backend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177b1da578832796f9ab772c8bcbd4)