### PR TITLE
Fix Python CGI imports for remote admin backend

### DIFF
--- a/www/cgi-bin/get_atcommand
+++ b/www/cgi-bin/get_atcommand
@@ -7,7 +7,15 @@ import sys
 
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[3]
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in current.parents:
+        if (candidate / "remote_admin_backend").is_dir():
+            return candidate
+    return current.parents[0]
+
+
+ROOT = _find_project_root()
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/www/cgi-bin/get_ping
+++ b/www/cgi-bin/get_ping
@@ -6,7 +6,15 @@ import os
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[3]
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in current.parents:
+        if (candidate / "remote_admin_backend").is_dir():
+            return candidate
+    return current.parents[0]
+
+
+ROOT = _find_project_root()
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/www/cgi-bin/get_uptime
+++ b/www/cgi-bin/get_uptime
@@ -6,7 +6,15 @@ import os
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[3]
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in current.parents:
+        if (candidate / "remote_admin_backend").is_dir():
+            return candidate
+    return current.parents[0]
+
+
+ROOT = _find_project_root()
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/www/cgi-bin/remote_config
+++ b/www/cgi-bin/remote_config
@@ -6,7 +6,15 @@ import os
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[3]
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in current.parents:
+        if (candidate / "remote_admin_backend").is_dir():
+            return candidate
+    return current.parents[0]
+
+
+ROOT = _find_project_root()
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/www/cgi-bin/remote_status
+++ b/www/cgi-bin/remote_status
@@ -6,7 +6,15 @@ import os
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[3]
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in current.parents:
+        if (candidate / "remote_admin_backend").is_dir():
+            return candidate
+    return current.parents[0]
+
+
+ROOT = _find_project_root()
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 

--- a/www/cgi-bin/user_atcommand
+++ b/www/cgi-bin/user_atcommand
@@ -6,7 +6,15 @@ import os
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[3]
+def _find_project_root() -> Path:
+    current = Path(__file__).resolve()
+    for candidate in current.parents:
+        if (candidate / "remote_admin_backend").is_dir():
+            return candidate
+    return current.parents[0]
+
+
+ROOT = _find_project_root()
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 


### PR DESCRIPTION
## Summary
- update each Python CGI script to locate the project root dynamically before importing the remote_admin_backend package
- ensure remote configuration requests return JSON responses instead of failing during credential saves

## Testing
- REQUEST_METHOD=GET python3 www/cgi-bin/remote_config
- REQUEST_METHOD=POST CONTENT_LENGTH=17 python3 www/cgi-bin/remote_config <<< '{"host":"router"}'


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69177d4c79ac8327bf9a8d2fea77b3ea)