### PR TITLE
Fix CGI handler detection for extensionless scripts

### DIFF
--- a/remote_admin_embedded.py
+++ b/remote_admin_embedded.py
@@ -4567,6 +4567,23 @@ def _make_handler(www_root: Path):
         def __init__(self, *args, directory: Optional[str] = None, **kwargs) -> None:
             super().__init__(*args, directory=str(www_root), **kwargs)
 
+        def is_python(self, path: str) -> bool:
+            """Treat extensionless scripts with a python shebang as Python."""
+            if super().is_python(path):
+                return True
+
+            scriptfile = path if os.path.isabs(path) else self.translate_path(path)
+            try:
+                with open(scriptfile, "rb") as candidate:
+                    first_line = candidate.readline()
+            except OSError:
+                return False
+
+            if not first_line.startswith(b"#!"):
+                return False
+
+            return b"python" in first_line.lower()
+
         def log_message(self, format: str, *args) -> None:  # noqa: A003 - match base signature
             if os.environ.get("REMOTE_ADMIN_QUIET"):
                 return


### PR DESCRIPTION
## Summary
- treat extensionless CGI scripts with a python shebang as Python scripts so they execute correctly on Windows

## Testing
- python -m compileall remote_admin_embedded.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918a1acc6b48327868e1bfefd33c1a0)