### PR TITLE
Fix asset extraction context manager usage

### DIFF
--- a/remote_admin_embedded.py
+++ b/remote_admin_embedded.py
@@ -3788,6 +3788,7 @@ ASSET_ARCHIVE_B64 = (
     'ACIA6AkAAAc9AwAAAA=='
 )
 
+@contextmanager
 def _prepare_assets() -> Iterator[Path]:
     """Extract embedded assets to a temporary directory."""
     with tempfile.TemporaryDirectory(prefix="simpleadmin-") as tmpdir:


### PR DESCRIPTION
## Summary
- decorate `_prepare_assets` with `@contextmanager` so it can be used in a `with` statement during server startup

## Testing
- python remote_admin_embedded.py --help

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b57cd00c88327b91c34b3404aa315)