### PR TITLE
Fix plus sign decoding in AT command handler

### DIFF
--- a/simpleadmin_assets/remote_admin_backend/http_utils.py
+++ b/simpleadmin_assets/remote_admin_backend/http_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import json
 import sys
 from typing import Any, Dict, Iterable, Tuple
-from urllib.parse import parse_qs, unquote_plus
+from urllib.parse import parse_qs, unquote
 
 
 def send_json(payload: Dict[str, Any], status: int = 200) -> None:
@@ -31,8 +31,8 @@ def parse_query(environ: Dict[str, str]) -> Dict[str, str]:
 
 
 def decode_param(value: str) -> str:
-    """Decode a percent-encoded parameter value."""
-    return unquote_plus(value or "")
+    """Decode a percent-encoded parameter value without altering plus signs."""
+    return unquote(value or "")
 
 
 def read_body(environ: Dict[str, str]) -> bytes:


### PR DESCRIPTION
## Summary
- switch CGI parameter decoding to `urllib.parse.unquote` so literal `+` symbols are preserved
- prevent AT commands such as `AT+CSQ` from being corrupted into `AT CSQ`, allowing the dashboard to read modem data again

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b693036708327bb3748ca51c212c8)