### PR TITLE
Fix duplicate dBm label in RSSI bars

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -425,7 +425,7 @@
                               :style="'width: ' + rssiLTEPercentage + '%'"
                             >
                               <span
-                                x-text="rssiLTE + ' dBm / ' + rssiLTEPercentage + '%'"
+                                x-text="rssiLTE + ' / ' + rssiLTEPercentage + '%'"
                               ></span>
                             </div>
                           </div>
@@ -609,7 +609,7 @@
                               :style="'width: ' + rssiNRPercentage + '%'"
                             >
                               <span
-                                x-text="rssiNR + ' dBm / ' + rssiNRPercentage + '%'"
+                                x-text="rssiNR + ' / ' + rssiNRPercentage + '%'"
                               ></span>
                             </div>
                           </div>


### PR DESCRIPTION
## Summary
- remove the hardcoded dBm label from the 4G and 5G RSSI progress bars so the value does not repeat the unit when it is already present in the data

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dfaa1c85883278cc47d846985fb1d)