### PR TITLE
Adjust APN card width for single-row layout

### DIFF
--- a/www/network.html
+++ b/www/network.html
@@ -154,7 +154,7 @@
         </div>
 
         <div class="row gap-3 mt-4">
-          <div class="col-12 col-lg-6 col-xl-6">
+          <div class="col-12 col-lg-5 col-xl-5">
             <div class="card">
               <div class="card-header pb-0">
                 <ul class="nav nav-tabs card-header-tabs">


### PR DESCRIPTION
## Summary
- reduce the APN Settings card column width to allow APN, Preferred Network, and Cell Locking cards to sit on a single row on larger screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e085e88e08327ae77f9d56b9260a5)