### PR TITLE
Allow hashed credentials for authentication

### DIFF
--- a/www/cgi-bin/session_utils.sh
+++ b/www/cgi-bin/session_utils.sh
@@ -157,6 +157,16 @@ authenticate_user() {
         SESSION_ROLE="$stored_role"
         return 0
     fi
+    # Allow passwords stored as SHA-256 hashes
+    if command -v sha256sum >/dev/null 2>&1; then
+        local password_hash
+        password_hash=$(printf '%s' "$password" | sha256sum | awk '{print $1}')
+        if [ "$password_hash" = "$stored_password" ]; then
+            SESSION_USERNAME="$stored_username"
+            SESSION_ROLE="$stored_role"
+            return 0
+        fi
+    fi
     return 1
 }
 


### PR DESCRIPTION
## Summary
- allow authenticate_user to validate passwords stored as SHA-256 hashes

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340d30ee408327863946b5498b511f)