### PR TITLE
Add fallback for eSIM management API

### DIFF
--- a/www/js/esim-config.js
+++ b/www/js/esim-config.js
@@ -12,15 +12,20 @@ const EsimConfig = (() => {
     })
       .then(async (response) => {
         if (!response.ok) {
+          console.debug("[eSIM] Configurazione eSIM non disponibile (response non OK)");
           return { enabled: false, base_url: "" };
         }
         const payload = await response.json();
         if (!payload || payload.success !== true) {
+          console.debug("[eSIM] Configurazione eSIM risposta non valida", payload);
           return { enabled: false, base_url: "" };
         }
         return payload.data || { enabled: false, base_url: "" };
       })
-      .catch(() => ({ enabled: false, base_url: "" }));
+      .catch((error) => {
+        console.debug("[eSIM] Errore durante il recupero della configurazione eSIM", error);
+        return { enabled: false, base_url: "" };
+      });
 
     return cachePromise;
   }


### PR DESCRIPTION
## Summary
- add a fallback base URL that swaps localhost endpoints with the device hostname when the local eSIM API cannot be reached and automatically switches once it works
- add debug logging across eSIM config retrieval and API calls to ease troubleshooting of connection issues

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c19e5b6088327bf34d8505135dfeb)