### PR TITLE
Enforce single credential format

### DIFF
--- a/www/cgi-bin/credentials.txt
+++ b/www/cgi-bin/credentials.txt
@@ -1,1 +1,1 @@
-admin:admin:8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
+admin:admin:admin


### PR DESCRIPTION
## Summary
- drop legacy credential normalization and old two-field compatibility
- require username:role:password entries with default admin:admin:admin bootstrap
- ensure admin bootstrapping uses the same three-field format

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c1d53621883278d7c208333975d4f)