### PR TITLE
Align eSIM notification actions with API requirements

### DIFF
--- a/www/esim.html
+++ b/www/esim.html
@@ -284,7 +284,14 @@
                     </div>
                     <div class="col-md-4">
                       <label class="form-label" for="removeSequence">Sequence # (opz.)</label>
-                      <input type="number" min="1" class="form-control" id="removeSequence" x-model="removeForm.sequence_number" />
+                      <input
+                        type="number"
+                        min="1"
+                        class="form-control"
+                        id="removeSequence"
+                        x-model="removeForm.sequence_number"
+                        :disabled="removeForm.remove_all"
+                      />
                     </div>
                     <div class="col-12 d-flex justify-content-end">
                       <button class="btn btn-outline-danger" type="submit">Rimuovi</button>


### PR DESCRIPTION
## Summary
- require a sequence number when processing a single notification to match API expectations
- validate remove-notification requests to ensure an ICCID or sequence is provided when not removing all
- disable the sequence number input when the form is set to remove all notifications

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c2096fb6c8327a435d86397bb1b76)