### PR TITLE
Guard eSIM Alpine registration

### DIFF
--- a/www/js/esim.js
+++ b/www/js/esim.js
@@ -1,5 +1,11 @@
-document.addEventListener("alpine:init", () => {
-  Alpine.data("esimManager", () => ({
+let esimManagerRegistered = false;
+
+function registerEsimManager(alpineInstance) {
+  if (esimManagerRegistered || !alpineInstance?.data) {
+    return;
+  }
+
+  alpineInstance.data("esimManager", () => ({
     loading: true,
     enabled: false,
     baseUrl: "",
@@ -336,4 +342,14 @@ document.addEventListener("alpine:init", () => {
       }
     },
   }));
-});
+
+  esimManagerRegistered = true;
+}
+
+if (window.Alpine) {
+  registerEsimManager(window.Alpine);
+} else {
+  document.addEventListener("alpine:init", (event) => {
+    registerEsimManager(event.detail);
+  });
+}


### PR DESCRIPTION
## Summary
- prevent registering the eSIM Alpine component multiple times and guard against missing Alpine instances
- register the component using the Alpine instance provided by the `alpine:init` event

## Testing
- npm test *(fails: repository has no package.json)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693c24a7f5308327a0196550cf849581)