### PR TITLE
Handle missing JSON responses in remote config UI

### DIFF
--- a/simpleadmin_assets/www/js/remote-config.js
+++ b/simpleadmin_assets/www/js/remote-config.js
@@ -42,13 +42,26 @@
     }
   }
 
+  async function readJson(response) {
+    try {
+      const text = await response.text();
+      if (!text) {
+        return null;
+      }
+      return JSON.parse(text);
+    } catch (error) {
+      console.warn("Invalid JSON response", error);
+      return null;
+    }
+  }
+
   async function loadConfig() {
     try {
       const response = await fetch("/cgi-bin/remote_config");
+      const data = await readJson(response);
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
+        throw new Error((data && data.message) || `HTTP ${response.status}`);
       }
-      const data = await response.json();
       if (!data || !data.config) {
         return;
       }
@@ -97,7 +110,7 @@
         body: JSON.stringify(payload),
       });
 
-      const data = await response.json();
+      const data = (await readJson(response)) || {};
       if (!response.ok || !data.success) {
         throw new Error(data.message || `HTTP ${response.status}`);
       }
@@ -114,7 +127,7 @@
     setStatus("Testing remote connection...", "info");
     try {
       const response = await fetch("/cgi-bin/remote_status");
-      const data = await response.json();
+      const data = (await readJson(response)) || {};
       if (!response.ok || !data.success) {
         throw new Error(data.message || `HTTP ${response.status}`);
       }


### PR DESCRIPTION
## Summary
- add safe JSON parsing helper for remote config and status fetches
- prevent UI errors when backend responds with empty or invalid JSON

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941b8a73288832794480aab37cdd11a)