### PR TITLE
Handle ATI success despite non-zero exit code

### DIFF
--- a/simpleadmin_assets/www/cgi-bin/remote_status
+++ b/simpleadmin_assets/www/cgi-bin/remote_status
@@ -24,15 +24,28 @@ def main() -> None:
         )
         return
 
-    if exit_code != 0 or stderr.strip():
-        message = stderr.strip() or f"ATI failed with exit code {exit_code}."
+    stderr_clean = stderr.strip()
+    stdout_clean = stdout.strip()
+
+    if stderr_clean:
         _respond(
             HTTPStatus.BAD_GATEWAY,
-            {"success": False, "message": message, "output": stdout.strip()},
+            {"success": False, "message": stderr_clean, "output": stdout_clean},
         )
         return
 
-    cleaned = stdout.strip() or "Modem responded."
+    if exit_code != 0 and "OK" not in stdout_clean.upper():
+        _respond(
+            HTTPStatus.BAD_GATEWAY,
+            {
+                "success": False,
+                "message": f"ATI failed with exit code {exit_code}.",
+                "output": stdout_clean,
+            },
+        )
+        return
+
+    cleaned = stdout_clean or "Modem responded."
     _respond(
         HTTPStatus.OK,
         {"success": True, "message": "Connection OK", "output": cleaned},


### PR DESCRIPTION
## Summary
- tolerate ATI responses that contain OK even when the router returns a non-zero exit code
- return clearer failure responses when stderr is present while preserving modem output for successes

## Testing
- python -m compileall simpleadmin_assets/www/cgi-bin/remote_status simpleadmin_assets/remote_admin_backend/ssh_client.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941c3f38d548327bef55cb6171c6802)