### PR TITLE
Add scheduled reboot configuration UI and endpoint

### DIFF
--- a/www/cgi-bin/reboot_schedule
+++ b/www/cgi-bin/reboot_schedule
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/session_utils.sh"
+
+SCHEDULE_FILE="/persist/reboot.txt"
+
+json_escape() {
+    python3 - <<'PY' "$1"
+import json, sys
+print(json.dumps(sys.argv[1]))
+PY
+}
+
+send_json() {
+    local status="$1"
+    local payload="$2"
+    printf 'Status: %s\r\n' "$status"
+    printf 'Content-type: application/json\r\n\r\n'
+    printf '%s\n' "$payload"
+    exit 0
+}
+
+url_decode() {
+    local data="${1//+/ }"
+    printf '%b' "${data//%/\\x}"
+}
+
+parse_params() {
+    local qs="$1"
+    IFS='&' read -ra pairs <<< "$qs"
+    for pair in "${pairs[@]}"; do
+        [ -z "$pair" ] && continue
+        key="${pair%%=*}"
+        val="${pair#*=}"
+        val=$(url_decode "$val")
+        case "$key" in
+            schedule) schedule="$val" ;;
+            action) action="$val" ;;
+        esac
+    done
+}
+
+ensure_auth() {
+    if ! session_load; then
+        send_json "401 Unauthorized" '{"success":false,"message":"Authentication required"}'
+    fi
+
+    if ! session_require_role "admin"; then
+        send_json "403 Forbidden" '{"success":false,"message":"Admin privileges required"}'
+    fi
+}
+
+read_schedule_file() {
+    if [ -f "$SCHEDULE_FILE" ]; then
+        schedule=$(grep -v '^\s*$' "$SCHEDULE_FILE" | head -n1)
+    else
+        schedule=""
+    fi
+}
+
+save_schedule() {
+    local schedule_line="$1"
+    mkdir -p "$(dirname "$SCHEDULE_FILE")"
+    printf '%s\n' "$schedule_line" > "$SCHEDULE_FILE"
+}
+
+validate_schedule() {
+    local line="$1"
+    local field_count
+    field_count=$(echo "$line" | awk '{print NF}')
+
+    if [ "$field_count" -lt 6 ]; then
+        send_json "400 Bad Request" '{"success":false,"message":"Invalid cron format. Expect at least 6 fields."}'
+    fi
+}
+
+handle_get() {
+    read_schedule_file
+    local schedule_json
+    schedule_json=$(json_escape "$schedule")
+    send_json "200 OK" "{\"success\":true,\"schedule\":${schedule_json}}"
+}
+
+handle_post() {
+    if [ -n "${CONTENT_LENGTH:-}" ]; then
+        read -r -n "$CONTENT_LENGTH" POST_DATA
+    else
+        read -r POST_DATA
+    fi
+    parse_params "$POST_DATA"
+
+    if [ "$action" = "delete" ] || [ -z "${schedule// }" ]; then
+        rm -f "$SCHEDULE_FILE"
+        send_json "200 OK" '{"success":true,"schedule":""}'
+    fi
+
+    validate_schedule "$schedule"
+    save_schedule "$schedule"
+    local schedule_json
+    schedule_json=$(json_escape "$schedule")
+    send_json "200 OK" "{\"success\":true,\"schedule\":${schedule_json}}"
+}
+
+ensure_auth
+
+case "$REQUEST_METHOD" in
+    GET)
+        handle_get
+        ;;
+    POST)
+        handle_post
+        ;;
+    DELETE)
+        action="delete"
+        handle_post
+        ;;
+    *)
+        send_json "405 Method Not Allowed" '{"success":false,"message":"Unsupported method"}'
+        ;;
+esac

--- a/www/network-settings.html
+++ b/www/network-settings.html
@@ -358,7 +358,168 @@
                     <div class="alert alert-info mt-3" role="alert">
                       <strong>Custom TTL active:</strong> Packets will be sent with TTL value of <span x-text="form.ttlValue"></span>.
                     </div>
-                  </template>                 
+                  </template>
+
+                  <hr class="my-4" />
+
+                  <div class="mb-3">
+                    <div class="d-flex align-items-center gap-2 mb-1">
+                      <h5 class="mb-0">Riavvio automatico</h5>
+                      <span class="badge text-bg-light">Salvato in reboot.txt (cron)</span>
+                    </div>
+                    <p class="text-body-secondary mb-3">
+                      Imposta un riavvio pianificato: l'impostazione viene salvata in formato compatibile con cron e potrai modificarla o cancellarla in seguito.
+                    </p>
+
+                    <div class="btn-group mb-3" role="group" aria-label="Auto reboot options">
+                      <button
+                        type="button"
+                        class="btn"
+                        :class="rebootForm.mode === 'interval' ? 'btn-primary' : 'btn-outline-primary'"
+                        @click="rebootForm.mode = 'interval'"
+                        :disabled="rebootSaving"
+                      >
+                        Ogni X ore
+                      </button>
+                      <button
+                        type="button"
+                        class="btn"
+                        :class="rebootForm.mode === 'schedule' ? 'btn-primary' : 'btn-outline-primary'"
+                        @click="rebootForm.mode = 'schedule'"
+                        :disabled="rebootSaving"
+                      >
+                        Programmazione
+                      </button>
+                    </div>
+
+                    <div class="row g-3" x-show="rebootForm.mode === 'interval'">
+                      <div class="col-md-4 col-lg-3">
+                        <label class="form-label" for="rebootIntervalHours">Ogni quante ore?</label>
+                        <div class="input-group">
+                          <input
+                            id="rebootIntervalHours"
+                            class="form-control"
+                            type="number"
+                            min="1"
+                            max="720"
+                            :disabled="rebootSaving"
+                            x-model.number="rebootForm.intervalHours"
+                          />
+                          <span class="input-group-text">ore</span>
+                        </div>
+                        <div class="form-text">Esegue un riavvio ogni N ore (es. 12 =&gt; <code>0 */12 * * * reboot</code>).</div>
+                      </div>
+                    </div>
+
+                    <div class="row g-3" x-show="rebootForm.mode === 'schedule'">
+                      <div class="col-md-4 col-lg-3">
+                        <label class="form-label" for="rebootFrequency">Frequenza</label>
+                        <select
+                          id="rebootFrequency"
+                          class="form-select"
+                          :disabled="rebootSaving"
+                          x-model="rebootForm.frequency"
+                        >
+                          <option value="daily">Ogni giorno</option>
+                          <option value="weekly">Ogni settimana</option>
+                          <option value="monthly">Ogni mese</option>
+                        </select>
+                      </div>
+
+                      <div class="col-md-4 col-lg-3" x-show="rebootForm.frequency === 'weekly'">
+                        <label class="form-label" for="rebootDayOfWeek">Giorno</label>
+                        <select
+                          id="rebootDayOfWeek"
+                          class="form-select"
+                          :disabled="rebootSaving"
+                          x-model="rebootForm.dayOfWeek"
+                        >
+                          <option value="1">Lunedì</option>
+                          <option value="2">Martedì</option>
+                          <option value="3">Mercoledì</option>
+                          <option value="4">Giovedì</option>
+                          <option value="5">Venerdì</option>
+                          <option value="6">Sabato</option>
+                          <option value="0">Domenica</option>
+                        </select>
+                      </div>
+
+                      <div class="col-md-4 col-lg-3" x-show="rebootForm.frequency === 'monthly'">
+                        <label class="form-label" for="rebootDayOfMonth">Giorno del mese</label>
+                        <input
+                          id="rebootDayOfMonth"
+                          class="form-control"
+                          type="number"
+                          min="1"
+                          max="31"
+                          :disabled="rebootSaving"
+                          x-model.number="rebootForm.dayOfMonth"
+                        />
+                        <div class="form-text">Esempio: 1 = ogni primo del mese.</div>
+                      </div>
+
+                      <div class="col-md-4 col-lg-3">
+                        <label class="form-label" for="rebootTime">Orario</label>
+                        <input
+                          id="rebootTime"
+                          class="form-control"
+                          type="time"
+                          step="60"
+                          :disabled="rebootSaving"
+                          x-model="rebootForm.time"
+                        />
+                        <div class="form-text">Esempi: 00:00 (mezzanotte), 16:00 (ogni giorno alle 16).</div>
+                      </div>
+                    </div>
+
+                    <div class="d-flex flex-wrap gap-2 mt-3">
+                      <button
+                        type="button"
+                        class="btn btn-primary"
+                        :disabled="rebootSaving"
+                        @click="saveRebootSchedule()"
+                      >
+                        Salva pianificazione
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-outline-secondary"
+                        :disabled="rebootSaving"
+                        @click="loadRebootSchedule()"
+                      >
+                        Annulla modifiche
+                      </button>
+                      <button
+                        type="button"
+                        class="btn btn-outline-danger"
+                        :disabled="rebootSaving || !rebootSchedule"
+                        @click="clearRebootSchedule()"
+                      >
+                        Rimuovi pianificazione
+                      </button>
+                    </div>
+
+                    <template x-if="rebootSuccessMessage">
+                      <div class="alert alert-success alert-dismissible fade show mt-3" role="alert">
+                        <span x-text="rebootSuccessMessage"></span>
+                        <button type="button" class="btn-close" @click="rebootSuccessMessage = ''"></button>
+                      </div>
+                    </template>
+
+                    <template x-if="rebootErrorMessage">
+                      <div class="alert alert-danger alert-dismissible fade show mt-3" role="alert">
+                        <span x-text="rebootErrorMessage"></span>
+                        <button type="button" class="btn-close" @click="rebootErrorMessage = ''"></button>
+                      </div>
+                    </template>
+
+                    <template x-if="rebootSchedule">
+                      <div class="alert alert-info mt-3" role="alert">
+                        <strong>Pianificazione corrente:</strong>
+                        <code x-text="rebootSchedule"></code>
+                      </div>
+                    </template>
+                  </div>
 
                   <template x-if="validationErrors.length">
                     <div class="alert alert-warning mt-4" role="alert">


### PR DESCRIPTION
## Summary
- add an auto-reboot configuration tab below the custom TTL section with interval and scheduled options
- persist the selected cron-formatted reboot schedule to reboot.txt via a new CGI endpoint and allow loading or clearing it

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942bfa279b483279e4ea47bd6e1e218)