### PR TITLE
Fix credential form parsing

### DIFF
--- a/www/cgi-bin/manage_credentials
+++ b/www/cgi-bin/manage_credentials
@@ -73,21 +73,30 @@ fi
 
 raw_body="$(read_body)"
 
-declare -A form
+username=""
+password=""
+role=""
+body_action="$action"
+
 IFS='&' read -r -a body_pairs <<< "$raw_body"
 for pair in "${body_pairs[@]}"; do
+    [ -z "$pair" ] && continue
     key="${pair%%=*}"
     value="${pair#*=}"
-    form["$key"]="$(urldecode "$value")"
+    decoded_value="$(urldecode "$value")"
+    case "$key" in
+        action) body_action="$decoded_value" ;;
+        username) username="$decoded_value" ;;
+        password) password="$decoded_value" ;;
+        role) role="$decoded_value" ;;
+    esac
 done
 
-action="${form[action]:-$action}"
+action="${body_action:-$action}"
 
 case "$action" in
     add)
-        username="${form[username]:-}"
-        password="${form[password]:-}"
-        role="${form[role]:-user}"
+        [ -z "$role" ] && role="user"
         if [ -z "$username" ] || [ -z "$password" ]; then
             bad_request
             exit 0
@@ -108,8 +117,6 @@ case "$action" in
         fi
         ;;
     update_password)
-        username="${form[username]:-}"
-        password="${form[password]:-}"
         if [ -z "$username" ] || [ -z "$password" ]; then
             bad_request
             exit 0
@@ -128,8 +135,6 @@ case "$action" in
         fi
         ;;
     update_role)
-        username="${form[username]:-}"
-        role="${form[role]:-}"
         if [ -z "$username" ] || [ -z "$role" ]; then
             bad_request
             exit 0
@@ -150,7 +155,6 @@ case "$action" in
         fi
         ;;
     delete)
-        username="${form[username]:-}"
         if [ -z "$username" ]; then
             bad_request
             exit 0


### PR DESCRIPTION
## Summary
- parse credential form fields without using associative arrays to improve CGI compatibility
- keep POST action detection while defaulting missing roles to the user role when adding

## Testing
- env SIMPLEADMIN_CONFIG_FILE=/dev/null SIMPLEADMIN_ENABLE_LOGIN=0 SIMPLEADMIN_CREDENTIALS_FILE=/tmp/creds_test REQUEST_METHOD=POST CONTENT_LENGTH=53 www/cgi-bin/manage_credentials <<< 'username=test&password=pass&action=add&role=user'

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694681300f2883279e1154771a8b76d9)