### PR TITLE
Allow removing guest while protecting admin

### DIFF
--- a/www/cgi-bin/manage_credentials
+++ b/www/cgi-bin/manage_credentials
@@ -127,8 +127,6 @@ case "$action" in
             status=$?
             if [ $status -eq 1 ]; then
                 send_json_response 404 '{"success":false,"message":"User not found"}'
-            elif [ $status -eq 3 ]; then
-                send_json_response 400 '{"success":false,"message":"Guest account cannot be modified"}'
             else
                 send_json_response 500 '{"success":false,"message":"Unable to update password"}'
             fi
@@ -147,8 +145,6 @@ case "$action" in
                 send_json_response 404 '{"success":false,"message":"User not found"}'
             elif [ $status -eq 2 ]; then
                 send_json_response 400 '{"success":false,"message":"Invalid role"}'
-            elif [ $status -eq 3 ]; then
-                send_json_response 400 '{"success":false,"message":"Guest account cannot be modified"}'
             else
                 send_json_response 500 '{"success":false,"message":"Unable to update role"}'
             fi
@@ -167,8 +163,8 @@ case "$action" in
                 send_json_response 404 '{"success":false,"message":"User not found"}'
             elif [ $status -eq 2 ]; then
                 send_json_response 409 '{"success":false,"message":"Cannot remove the last admin"}'
-            elif [ $status -eq 3 ]; then
-                send_json_response 400 '{"success":false,"message":"Guest account cannot be removed"}'
+            elif [ $status -eq 4 ]; then
+                send_json_response 400 '{"success":false,"message":"Admin account cannot be removed"}'
             else
                 send_json_response 500 '{"success":false,"message":"Unable to remove user"}'
             fi

--- a/www/cgi-bin/session_utils.sh
+++ b/www/cgi-bin/session_utils.sh
@@ -328,7 +328,6 @@ ensure_guest_exists_locked() {
 
 ensure_defaults_locked() {
     ensure_admin_exists_locked
-    ensure_guest_exists_locked
 }
 
 list_users() {
@@ -386,9 +385,6 @@ update_password() {
     local username="$1"
     local password="$2"
     ensure_credentials_file
-    if [ "$username" = "guest" ]; then
-        return 3
-    fi
     local lock="${CREDENTIALS_FILE}.lock"
     {
         flock -x 200
@@ -406,9 +402,6 @@ update_role() {
     local username="$1"
     local role="$2"
     ensure_credentials_file
-    if [ "$username" = "guest" ]; then
-        return 3
-    fi
     if ! validate_role "$role"; then
         return 2
     fi
@@ -428,8 +421,8 @@ update_role() {
 delete_user() {
     local username="$1"
     ensure_credentials_file
-    if [ "$username" = "guest" ]; then
-        return 3
+    if [ "$username" = "admin" ]; then
+        return 4
     fi
     local lock="${CREDENTIALS_FILE}.lock"
     {


### PR DESCRIPTION
## Summary
- allow guest account to be removed or updated while keeping admin deletion blocked
- stop re-adding the guest account automatically and adjust success/error messages
- keep admin password updates allowed while preventing deletion

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946853c0a1483278f17dad53013a0ff)