### PR TITLE
Avoid merging SMS entries by timestamp

### DIFF
--- a/www/js/sms.js
+++ b/www/js/sms.js
@@ -82,7 +82,6 @@ return {
     this.senders = [];
     this.messages = [];
     let match;
-    let lastIndex = null;
     while ((match = cmglRegex.exec(data)) !== null) {
       const index = parseInt(match[1]);
       const senderHex = match[2];
@@ -111,17 +110,10 @@ return {
       const messageRaw = data.substring(startIndex, endIndex).trim();
       const messageHex = this.extractHexPayload(messageRaw);
       const message = messageHex ? this.decodeHexToText(messageHex) : messageRaw;
-      if (lastIndex !== null && this.messages[lastIndex].sender === sender && (date - this.messages[lastIndex].date) / 1000 <= 1) {
-        this.messages[lastIndex].text += " " + message;
-        this.messages[lastIndex].indices.push(index);
-        this.dates[lastIndex] = this.formatDate(date);
-      } else {
-        this.messageIndices.push([index]);
-        this.senders.push(sender);
-        this.dates.push(this.formatDate(date));
-        this.messages.push({ text: message, sender: sender, date: date, indices: [index] });
-        lastIndex = this.messages.length - 1;
-      }
+      this.messageIndices.push([index]);
+      this.senders.push(sender);
+      this.dates.push(this.formatDate(date));
+      this.messages.push({ text: message, sender: sender, date: date, indices: [index] });
     }
     while ((match = cscaRegex.exec(data)) !== null) {
       const serviceCenterHex = match[1];


### PR DESCRIPTION
### Motivation
- The SMS parser was combining multiple modem `+CMGL` entries into a single UI message when they had the same sender and nearly identical timestamps.  
- This caused distinct modem messages (separate indices) to appear merged in the inbox UI.  

### Description
- Changed the SMS parsing logic in `www/js/sms.js` to stop merging entries by timestamp and sender.  
- Removed the `lastIndex` merging branch inside `parseSMSData` and now push one UI entry per `+CMGL` index.  
- The `messageIndices`, `senders`, `dates`, and `messages` arrays are populated so each modem index becomes a separate UI message.  

### Testing
- No automated tests were run for this UI-only change.  
- Change is limited to `parseSMSData` in `www/js/sms.js` and intended to preserve one-to-one mapping between modem indices and UI entries.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952d32d8e1c83278c1500d1ac573c5a)