### PR TITLE
Use frequency-based band tiering and add network analysis advisor

### DIFF
--- a/NETWORK_ANALYSIS_ADVISOR.md
+++ b/NETWORK_ANALYSIS_ADVISOR.md
@@ -1,0 +1,224 @@
+# Network Analysis Advisor (RM502Q)
+
+This document describes the logic implemented for the network analysis advisor shown in **Advanced Signal Details**.
+
+## Goal
+
+The advisor inspects per-band LTE (up to 5CA) and NR (up to 1CA) metrics and returns:
+
+- **Primary diagnosis** (title + short message)
+- **Why** (triggering metrics)
+- **What to try** (actionable suggestions)
+- **Secondary notes** (optional)
+
+If there are no clear signals or the conditions are too weak, it avoids noisy warnings.
+
+## Inputs per carrier/band
+
+For each observed carrier (LTE PCC + LTE SCCs; NR if present):
+
+- `rat`: LTE | NR
+- `band`: band number (e.g., 28, 20, 8, 3, 1, 7, 38, 78)
+- `rsrp_dBm`
+- `rsrq_dB`
+- `sinr_dB`
+- `rssi_dBm` (optional)
+- `is_aggregated` (optional, if known)
+- `timestamp` (optional)
+
+## Band tiering
+
+`tier(band)` is derived from the downlink center frequency:
+
+- **LOW**: < 1000 MHz
+- **MID**: 1000–2299 MHz
+- **HIGH**: ≥ 2300 MHz
+
+The implementation uses a band-to-frequency table (DL ranges) and computes the band center in MHz. Example mappings currently included:
+
+- **LTE**: 1 (2110–2170), 3 (1805–1880), 7 (2620–2690), 8 (925–960), 20 (791–821), 28 (758–803), 32 (1452–1496), 38 (2570–2620)
+- **NR**: n28 (758–803), n38 (2570–2620), n78 (3300–3800)
+
+**Note:** MID is treated like LOW for distance/attenuation checks.
+
+## Per-carrier score
+
+Metric percentages (from `lte_signal_score_formulas_rm502q.txt`) are used:
+
+- `sinr_pct`, `rsrp_pct`, `rsrq_pct`, `rssi_pct` (optional)
+
+**CarrierScore (0..100):**
+
+```
+CarrierScore = 0.45*sinr_pct + 0.35*rsrp_pct + 0.20*rsrq_pct
+```
+
+## Robust aggregation
+
+To avoid a single outlier dominating the result:
+
+- **Median** per LTE/NR:
+  - `LTE_rsrp_med`, `LTE_rsrq_med`, `LTE_sinr_med`, `LTE_score_med`
+  - `NR_rsrp_med`, `NR_rsrq_med`, `NR_sinr_med`, `NR_score_med`
+- **Tier split (LTE only):**
+  - `LTE_low_rsrp_med`: median RSRP for LTE carriers in LOW or MID
+  - `LTE_high_rsrp_med`: median RSRP for LTE carriers in HIGH
+- **Helpers:**
+  - `LTE_best_rsrp`: max LTE RSRP (least negative)
+  - `LTE_worst_sinr`: min LTE SINR
+  - `LTE_ca_count`: number of LTE carriers observed
+  - `NR_count`: number of NR carriers (0 or 1)
+
+## Distance/attenuation indicator
+
+If LTE_high is present:
+
+```
+delta_low_high = LTE_low_rsrp_med - LTE_high_rsrp_med
+```
+
+If LTE_high is absent, `LTE_high_rsrp_med` is treated as very low (e.g., -140) and `LTE_high_count == 0` is tracked explicitly.
+
+**Thresholds:**
+
+- `delta_low_high >= 12 dB` → **noticeable**
+- `delta_low_high >= 18 dB` → **strong**
+
+## Practical thresholds
+
+**RSRP**
+- good ≥ -90
+- ok   -90..-100
+- weak -100..-110
+- poor < -110
+
+**SINR**
+- good ≥ 10
+- ok   5..10
+- weak 0..5
+- poor < 0
+
+**RSRQ**
+- good ≥ -10
+- ok   -10..-12
+- weak -12..-15
+- poor < -15
+
+## Output
+
+Object with:
+
+- `primary_title`
+- `primary_message`
+- `why` (2–4 bullets)
+- `suggestions` (1–3 bullets)
+- `secondary_notes` (optional)
+
+If no rule meets sufficient confidence, output is **“No issues detected”**.
+
+## Evaluation order (priority)
+
+The advisor evaluates rules in this order and selects the first strong match as primary. Weaker matches become **secondary notes**.
+
+### Rule 0 — No issues detected
+
+**Trigger:**
+
+- `LTE_score_med >= 80` (or `NR_score_med >= 80` when NR is present)
+- No congestion rule triggers
+
+**Output:**
+- “No issues detected”
+
+### Rule A — Likely far from site / strong attenuation (low strong, high weak/absent)
+
+**Trigger:**
+
+- `LTE_low_rsrp_med >= -95`
+- `LTE_high_count == 0` **or** `LTE_high_rsrp_med <= -108`
+- `delta_low_high >= 12` (**strong** if ≥ 18)
+
+**Output:**
+- “Likely far from the antenna / strong attenuation”
+
+**Why includes:**
+- `LTE_low_rsrp_med`, `LTE_high_rsrp_med`, `delta_low_high`, `LTE_high_count`
+
+**Suggestions:**
+- move the router toward a window / higher position
+- small rotations/repositioning (especially with directional antennas)
+
+### Rule B — Likely congestion/interference (strong signal but low quality)
+
+**LTE congested:**
+- `LTE_rsrp_med >= -95`
+- **and** (`LTE_sinr_med <= 3` **or** `LTE_rsrq_med <= -12`)
+
+**NR congested:**
+- `NR_rsrp_med >= -95`
+- **and** (`NR_sinr_med <= 3` **or** `NR_rsrq_med <= -12`)
+
+**Output:**
+- “Likely 4G cell congestion/interference” (LTE only)
+- “Likely 5G cell congestion/interference” (NR only)
+- “Likely 4G/5G congestion/interference” (both)
+
+**Suggestions:**
+- try a different band/cell (if the UI supports locking)
+- test at different times of day
+- small re-aim adjustments with directional antennas
+
+### Rule C — 4G very good (multi-CA) but 5G poor/absent
+
+**Trigger:**
+
+- `LTE_ca_count >= 3`
+- `LTE_score_med >= 75`
+- `NR_count == 0` **or** `NR_rsrp_med <= -110` **or** `NR_score_med <= 40`
+
+**Output:**
+- “5G reception seems suboptimal vs 4G”
+
+**Suggestions:**
+- reposition/rotate toward the likely 5G direction (n78 is more sensitive)
+- verify 5G availability and test near a window/outdoors
+
+### Rule D — Uniformly low coverage
+
+**Trigger:**
+
+- `LTE_rsrp_med <= -105`
+- `NR_count == 0` **or** `NR_rsrp_med <= -105`
+- `delta_low_high < 12` (or `LTE_high_count == 0` and low-band is also weak)
+
+**Output:**
+- “Overall coverage is weak”
+
+**Suggestions:**
+- improve placement (window/high spot), external antenna, avoid thick walls
+
+### Rule E — Carrier aggregation limited by weak signal
+
+**Trigger:**
+
+- `LTE_ca_count <= 2`
+- `LTE_best_rsrp <= -100` (or `LTE_rsrp_med <= -100`)
+
+**Output:**
+- “Signal likely too weak for higher CA”
+
+**Suggestions:**
+- improve RSRP first (placement/antenna) to enable more stable CA
+
+## Confidence (optional)
+
+Simple confidence score 0..100:
+
+- base: 50
+- +10 if `LTE_ca_count >= 3`
+- +10 if `LTE_high_count > 0`
+- +10 for a “strong” condition (delta ≥ 18, SINR < 0, RSRQ < -15, etc.)
+
+Usage:
+- < 60 → no primary, optionally secondary notes
+- optional UI badge

--- a/www/index.html
+++ b/www/index.html
@@ -1010,6 +1010,54 @@
                     </div>
                   </div>
                 </template>
+
+                <div class="mt-4">
+                  <h6 class="fw-semibold">Network analysis</h6>
+                  <template x-if="!networkAnalysis">
+                    <p class="mb-0 text-muted">No network analysis available.</p>
+                  </template>
+                  <template x-if="networkAnalysis">
+                    <div class="small">
+                      <p class="mb-1">
+                        <strong x-text="networkAnalysis.primary_title"></strong>
+                      </p>
+                      <p class="mb-2" x-text="networkAnalysis.primary_message"></p>
+
+                      <template x-if="networkAnalysis.why && networkAnalysis.why.length">
+                        <div class="mb-2">
+                          <div class="text-muted fw-semibold">Why</div>
+                          <ul class="mb-2 ps-3">
+                            <template x-for="(item, idx) in networkAnalysis.why" :key="'why-' + idx">
+                              <li x-text="item"></li>
+                            </template>
+                          </ul>
+                        </div>
+                      </template>
+
+                      <template x-if="networkAnalysis.suggestions && networkAnalysis.suggestions.length">
+                        <div class="mb-2">
+                          <div class="text-muted fw-semibold">What to try</div>
+                          <ul class="mb-2 ps-3">
+                            <template x-for="(item, idx) in networkAnalysis.suggestions" :key="'suggestion-' + idx">
+                              <li x-text="item"></li>
+                            </template>
+                          </ul>
+                        </div>
+                      </template>
+
+                      <template x-if="networkAnalysis.secondary_notes && networkAnalysis.secondary_notes.length">
+                        <div class="mb-0">
+                          <div class="text-muted fw-semibold">Notes</div>
+                          <ul class="mb-0 ps-3">
+                            <template x-for="(item, idx) in networkAnalysis.secondary_notes" :key="'note-' + idx">
+                              <li x-text="item"></li>
+                            </template>
+                          </ul>
+                        </div>
+                      </template>
+                    </div>
+                  </template>
+                </div>
               </div>
             </div>
           </div>

--- a/www/js/index-process.js
+++ b/www/js/index-process.js
@@ -146,6 +146,8 @@ function processAllInfos() {
     uploadStat: "0",
     // Detailed signal measurements for multiple cells
     detailedSignals: [],
+    // Network analysis advisor output
+    networkAnalysis: null,
     // Auto-refresh interval ID
     intervalId: null,
     // Phone number
@@ -448,6 +450,7 @@ function processAllInfos() {
                 id: currentEntry.id,
                 title,
                 technology: currentEntry.technology,
+                band: currentEntry.band,
                 bandDisplay,
                 bandwidthDisplay: currentEntry.bandwidth || "N/A",
                 channelDisplay: currentEntry.channel || "N/A",
@@ -836,6 +839,7 @@ function processAllInfos() {
           };
 
           this.detailedSignals = buildDetailedSignals();
+          this.networkAnalysis = this.buildNetworkAnalysis(this.detailedSignals);
 
           // --- Temperature ---
           try {
@@ -2082,6 +2086,362 @@ function processAllInfos() {
     const result = this.calculateSINRBar(sinr);
     return result.percentage;
   },
+
+  buildNetworkAnalysis(detailedSignals) {
+    if (!Array.isArray(detailedSignals) || detailedSignals.length === 0) {
+      return null;
+    }
+
+    const carriers = detailedSignals.map((entry) => {
+      const getMetricValue = (key) => {
+        const metric = Array.isArray(entry.metrics)
+          ? entry.metrics.find((item) => item.key === key)
+          : null;
+        return metric && typeof metric.value === "number" ? metric.value : null;
+      };
+
+      const bandRaw = entry.band || entry.bandDisplay || "";
+      const bandNumber = typeof bandRaw === "number"
+        ? bandRaw
+        : parseInt(String(bandRaw).replace(/\D/g, ""), 10);
+
+      return {
+        rat: entry.technology,
+        band: Number.isNaN(bandNumber) ? null : bandNumber,
+        rsrp_dBm: getMetricValue("rsrp"),
+        rsrq_dB: getMetricValue("rsrq"),
+        sinr_dB: getMetricValue("sinr"),
+        rssi_dBm: getMetricValue("rssi"),
+      };
+    });
+
+    const lteCarriers = carriers.filter((carrier) => carrier.rat === "LTE");
+    const nrCarriers = carriers.filter((carrier) => carrier.rat === "NR");
+
+    const median = (values) => {
+      const items = values.filter((value) => typeof value === "number").sort((a, b) => a - b);
+      if (items.length === 0) {
+        return null;
+      }
+      const mid = Math.floor(items.length / 2);
+      return items.length % 2 === 0
+        ? (items[mid - 1] + items[mid]) / 2
+        : items[mid];
+    };
+
+    const getBandCenterMHz = (rat, band) => {
+      if (!band) {
+        return null;
+      }
+
+      const lteBandsMHz = {
+        1: { dlMin: 2110, dlMax: 2170 },
+        3: { dlMin: 1805, dlMax: 1880 },
+        7: { dlMin: 2620, dlMax: 2690 },
+        8: { dlMin: 925, dlMax: 960 },
+        20: { dlMin: 791, dlMax: 821 },
+        28: { dlMin: 758, dlMax: 803 },
+        32: { dlMin: 1452, dlMax: 1496 },
+        38: { dlMin: 2570, dlMax: 2620 },
+      };
+
+      const nrBandsMHz = {
+        28: { dlMin: 758, dlMax: 803 },
+        38: { dlMin: 2570, dlMax: 2620 },
+        78: { dlMin: 3300, dlMax: 3800 },
+      };
+
+      const table = rat === "NR" ? nrBandsMHz : lteBandsMHz;
+      const bandInfo = table[band];
+      if (!bandInfo) {
+        return null;
+      }
+      return (bandInfo.dlMin + bandInfo.dlMax) / 2;
+    };
+
+    const getTier = (band, rat) => {
+      const centerMHz = getBandCenterMHz(rat, band);
+      if (typeof centerMHz !== "number") {
+        return null;
+      }
+      if (centerMHz < 1000) {
+        return "LOW";
+      }
+      if (centerMHz < 2300) {
+        return "MID";
+      }
+      return "HIGH";
+    };
+
+    const buildScores = (carrier) => {
+      const sinrPct = typeof carrier.sinr_dB === "number"
+        ? this.calculateSINRPercentage(carrier.sinr_dB)
+        : 0;
+      const rsrpPct = typeof carrier.rsrp_dBm === "number"
+        ? this.calculateRSRPPercentage(carrier.rsrp_dBm)
+        : 0;
+      const rsrqPct = typeof carrier.rsrq_dB === "number"
+        ? this.calculateRSRQPercentage(carrier.rsrq_dB)
+        : 0;
+      return this.calculateSignalPercentage(sinrPct, rsrpPct, rsrqPct);
+    };
+
+    const lteScores = lteCarriers.map(buildScores);
+    const nrScores = nrCarriers.map(buildScores);
+
+    const lteRsrpMed = median(lteCarriers.map((carrier) => carrier.rsrp_dBm));
+    const lteRsrqMed = median(lteCarriers.map((carrier) => carrier.rsrq_dB));
+    const lteSinrMed = median(lteCarriers.map((carrier) => carrier.sinr_dB));
+    const lteScoreMed = median(lteScores);
+
+    const nrRsrpMed = median(nrCarriers.map((carrier) => carrier.rsrp_dBm));
+    const nrRsrqMed = median(nrCarriers.map((carrier) => carrier.rsrq_dB));
+    const nrSinrMed = median(nrCarriers.map((carrier) => carrier.sinr_dB));
+    const nrScoreMed = median(nrScores);
+
+    const lteLowBands = lteCarriers.filter((carrier) => {
+      const tier = getTier(carrier.band, "LTE");
+      return tier === "LOW" || tier === "MID";
+    });
+    const lteHighBands = lteCarriers.filter((carrier) => getTier(carrier.band, "LTE") === "HIGH");
+
+    const lteLowRsrpMed = median(lteLowBands.map((carrier) => carrier.rsrp_dBm));
+    const lteHighRsrpMed = median(lteHighBands.map((carrier) => carrier.rsrp_dBm));
+    const lteHighCount = lteHighBands.length;
+
+    const adjustedHighRsrp = typeof lteHighRsrpMed === "number" ? lteHighRsrpMed : -140;
+    const deltaLowHigh = typeof lteLowRsrpMed === "number"
+      ? lteLowRsrpMed - adjustedHighRsrp
+      : null;
+
+    const lteBestRsrp = lteCarriers.reduce((best, carrier) => {
+      if (typeof carrier.rsrp_dBm !== "number") {
+        return best;
+      }
+      return best === null ? carrier.rsrp_dBm : Math.max(best, carrier.rsrp_dBm);
+    }, null);
+
+    const lteCaCount = lteCarriers.length;
+    const nrCount = nrCarriers.length;
+
+    const lteCongested = typeof lteRsrpMed === "number" &&
+      lteRsrpMed >= -95 &&
+      ((typeof lteSinrMed === "number" && lteSinrMed <= 3) ||
+        (typeof lteRsrqMed === "number" && lteRsrqMed <= -12));
+
+    const nrCongested = nrCount > 0 &&
+      typeof nrRsrpMed === "number" &&
+      nrRsrpMed >= -95 &&
+      ((typeof nrSinrMed === "number" && nrSinrMed <= 3) ||
+        (typeof nrRsrqMed === "number" && nrRsrqMed <= -12));
+
+    const formatValue = (value, unit) => {
+      if (typeof value !== "number") {
+        return "N/A";
+      }
+      const rounded = Math.round(value * 10) / 10;
+      return unit ? `${rounded} ${unit}` : `${rounded}`;
+    };
+
+    const buildConfidence = ({ strong = false } = {}) => {
+      let confidence = 50;
+      if (lteCaCount >= 3) {
+        confidence += 10;
+      }
+      if (lteHighCount > 0) {
+        confidence += 10;
+      }
+      if (strong) {
+        confidence += 10;
+      }
+      return Math.min(100, Math.max(0, confidence));
+    };
+
+    const secondaryNotes = [];
+
+    if (!lteCongested && !nrCongested) {
+      const overallGood = (typeof lteScoreMed === "number" && lteScoreMed >= 80) ||
+        (nrCount > 0 && typeof nrScoreMed === "number" && nrScoreMed >= 80);
+      if (overallGood) {
+        return {
+          primary_title: "No issues detected",
+          primary_message: "Signal quality looks good across the observed carriers.",
+          why: [],
+          suggestions: [],
+          secondary_notes: [],
+        };
+      }
+    }
+
+    const ruleA =
+      typeof lteLowRsrpMed === "number" &&
+      lteLowRsrpMed >= -95 &&
+      (lteHighCount === 0 || (typeof lteHighRsrpMed === "number" && lteHighRsrpMed <= -108)) &&
+      typeof deltaLowHigh === "number" &&
+      deltaLowHigh >= 12;
+
+    if (ruleA) {
+      const confidence = buildConfidence({ strong: deltaLowHigh >= 18 });
+      if (confidence >= 60) {
+        return {
+          primary_title: "Likely far from the antenna / strong attenuation",
+          primary_message: "Low-band LTE looks healthy while higher bands are weak or missing.",
+          why: [
+            `LTE low-band median RSRP: ${formatValue(lteLowRsrpMed, "dBm")}`,
+            `LTE high-band median RSRP: ${formatValue(lteHighRsrpMed, "dBm")} (${lteHighCount} bands)`,
+            `Low vs high delta: ${formatValue(deltaLowHigh, "dB")}`,
+          ],
+          suggestions: [
+            "Move the router toward a window or higher position.",
+            "Try small rotations/repositioning (especially with directional antennas).",
+          ],
+          secondary_notes: [],
+        };
+      }
+      secondaryNotes.push("Possible low vs high band imbalance (distance/attenuation).");
+    }
+
+    if (lteCongested || nrCongested) {
+      const strong = (typeof lteSinrMed === "number" && lteSinrMed < 0) ||
+        (typeof lteRsrqMed === "number" && lteRsrqMed < -15) ||
+        (typeof nrSinrMed === "number" && nrSinrMed < 0) ||
+        (typeof nrRsrqMed === "number" && nrRsrqMed < -15);
+      const confidence = buildConfidence({ strong });
+      if (confidence >= 60) {
+        let title = "Likely congestion/interference";
+        if (lteCongested && !nrCongested) {
+          title = "Likely 4G cell congestion/interference";
+        } else if (nrCongested && !lteCongested) {
+          title = "Likely 5G cell congestion/interference";
+        } else if (lteCongested && nrCongested) {
+          title = "Likely 4G/5G congestion/interference";
+        }
+        const why = [];
+        if (lteCongested) {
+          why.push(`LTE RSRP median: ${formatValue(lteRsrpMed, "dBm")}`);
+          why.push(`LTE SINR median: ${formatValue(lteSinrMed, "dB")}`);
+          why.push(`LTE RSRQ median: ${formatValue(lteRsrqMed, "dB")}`);
+        }
+        if (nrCongested) {
+          why.push(`NR RSRP median: ${formatValue(nrRsrpMed, "dBm")}`);
+          why.push(`NR SINR median: ${formatValue(nrSinrMed, "dB")}`);
+          why.push(`NR RSRQ median: ${formatValue(nrRsrqMed, "dB")}`);
+        }
+        return {
+          primary_title: title,
+          primary_message: "Strong signal levels with low quality typically indicate congestion or interference.",
+          why,
+          suggestions: [
+            "Try a different band/cell if your UI supports locking.",
+            "Test at different times of day.",
+            "If using a directional antenna, try small re-aim adjustments.",
+          ],
+          secondary_notes: [],
+        };
+      }
+      secondaryNotes.push("Possible congestion/interference detected.");
+    }
+
+    const ruleC = lteCaCount >= 3 &&
+      typeof lteScoreMed === "number" &&
+      lteScoreMed >= 75 &&
+      (nrCount === 0 ||
+        (typeof nrRsrpMed === "number" && nrRsrpMed <= -110) ||
+        (typeof nrScoreMed === "number" && nrScoreMed <= 40));
+
+    if (ruleC) {
+      const confidence = buildConfidence({ strong: nrCount === 0 || (typeof nrScoreMed === "number" && nrScoreMed <= 30) });
+      if (confidence >= 60) {
+        return {
+          primary_title: "5G reception seems suboptimal vs 4G",
+          primary_message: "LTE carrier aggregation looks good, but 5G is weak or absent.",
+          why: [
+            `LTE CA count: ${lteCaCount}`,
+            `LTE score median: ${formatValue(lteScoreMed, "")}`,
+            `NR count: ${nrCount}`,
+            `NR RSRP/score: ${formatValue(nrRsrpMed, "dBm")} / ${formatValue(nrScoreMed, "")}`,
+          ],
+          suggestions: [
+            "Reposition/rotate the device toward the likely 5G direction (n78 is more sensitive).",
+            "Verify 5G availability at your location and test near a window/outdoors.",
+          ],
+          secondary_notes: [],
+        };
+      }
+      secondaryNotes.push("5G appears weaker than strong LTE CA.");
+    }
+
+    const weakCoverage = typeof lteRsrpMed === "number" && lteRsrpMed <= -105 &&
+      (nrCount === 0 || (typeof nrRsrpMed === "number" && nrRsrpMed <= -105));
+    const lowHighBalanced = typeof deltaLowHigh === "number" ? deltaLowHigh < 12 : true;
+    const ruleD = weakCoverage &&
+      (lowHighBalanced || (lteHighCount === 0 && typeof lteLowRsrpMed === "number" && lteLowRsrpMed <= -105));
+
+    if (ruleD) {
+      const confidence = buildConfidence({ strong: typeof lteRsrpMed === "number" && lteRsrpMed <= -110 });
+      if (confidence >= 60) {
+        const why = [
+          `LTE RSRP median: ${formatValue(lteRsrpMed, "dBm")}`,
+        ];
+        if (nrCount > 0) {
+          why.push(`NR RSRP median: ${formatValue(nrRsrpMed, "dBm")}`);
+        }
+        return {
+          primary_title: "Overall coverage is weak",
+          primary_message: "All observed carriers show weak signal levels.",
+          why,
+          suggestions: [
+            "Try a better placement (near a window or higher position).",
+            "Consider an external antenna and avoid thick walls.",
+          ],
+          secondary_notes: [],
+        };
+      }
+      secondaryNotes.push("Overall coverage looks weak.");
+    }
+
+    const ruleE = lteCaCount <= 2 &&
+      ((typeof lteBestRsrp === "number" && lteBestRsrp <= -100) ||
+        (typeof lteRsrpMed === "number" && lteRsrpMed <= -100));
+
+    if (ruleE) {
+      const confidence = buildConfidence({ strong: typeof lteBestRsrp === "number" && lteBestRsrp <= -105 });
+      if (confidence >= 60) {
+        return {
+          primary_title: "Signal likely too weak for higher CA",
+          primary_message: "Limited carrier aggregation is typical when signal strength is low.",
+          why: [
+            `LTE CA count: ${lteCaCount}`,
+            `Best LTE RSRP: ${formatValue(lteBestRsrp, "dBm")}`,
+          ],
+          suggestions: [
+            "Improve RSRP first (placement/antenna) to enable more stable CA.",
+          ],
+          secondary_notes: [],
+        };
+      }
+      secondaryNotes.push("Carrier aggregation may be limited by weak signal.");
+    }
+
+    if (secondaryNotes.length > 0) {
+      return {
+        primary_title: "No issues detected",
+        primary_message: "No strong issues were detected, but see secondary notes.",
+        why: [],
+        suggestions: [],
+        secondary_notes: secondaryNotes,
+      };
+    }
+
+    return {
+      primary_title: "No issues detected",
+      primary_message: "No clear issues were detected with the current signals.",
+      why: [],
+      suggestions: [],
+      secondary_notes: [],
+    };
+  },
+
   // Calculate the overall signal assessment
   calculateSignalPercentage(sinrPercentage, rsrpPercentage, rsrqPercentage) {
     const sinr = Number.isFinite(sinrPercentage) ? sinrPercentage : 0;


### PR DESCRIPTION
### Motivation
- Replace brittle static band lists with frequency-based tiering so band classification adapts to actual downlink center frequencies.
- Ensure LTE band `32` (and NR mappings) are classified correctly by computing tier from DL center MHz instead of hard-coded arrays.
- Provide a documented mapping and thresholds to keep advisor docs aligned with runtime behavior in `NETWORK_ANALYSIS_ADVISOR.md`.
- Surface per-carrier analysis in the UI so users can see advisor output alongside detailed signals.

### Description
- Implemented `getBandCenterMHz` and replaced the old `getTier` logic with a center-frequency based tier computation in `www/js/index-process.js` using `<1000MHz` = `LOW`, `1000–2299MHz` = `MID`, and `>=2300MHz` = `HIGH`.
- Added `buildNetworkAnalysis` to compute medians, scores, tier splits, detection rules (distance/attenuation, congestion, CA/5G mismatches), and a simple confidence heuristic, and integrated it into `processAllInfos` to populate `networkAnalysis` state.
- Updated `NETWORK_ANALYSIS_ADVISOR.md` to document the frequency thresholds and the included LTE/NR band-to-frequency examples and rationale.
- Added a UI block in `www/index.html` and a `networkAnalysis` field in the component state to display `primary_title`, `primary_message`, `why`, `suggestions`, and `secondary_notes`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d66a8775c83279118ba39333ed8a4)