### PR TITLE
Adjust SIM PIN unlock options: permanent or until reboot

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -901,6 +901,48 @@
                     </tbody>
                   </table>
                 </div>
+                <div x-show="isSimPinRequired()" class="mt-3">
+                  <hr class="my-3" />
+                  <h6 class="fw-semibold">Unlock SIM PIN</h6>
+                  <p class="text-muted small mb-3">Enter the SIM PIN to unlock the SIM. Choose whether to disable the PIN permanently or until reboot.</p>
+                  <div class="alert alert-success py-2" role="alert" x-show="simUnlockMessage" x-text="simUnlockMessage"></div>
+                  <div class="alert alert-danger py-2" role="alert" x-show="simUnlockError" x-text="simUnlockError"></div>
+                  <div class="mb-3">
+                    <label for="simPinInput" class="form-label">SIM PIN</label>
+                    <input
+                      id="simPinInput"
+                      type="password"
+                      inputmode="numeric"
+                      class="form-control"
+                      x-model="simPin"
+                      placeholder="Enter PIN"
+                      autocomplete="off"
+                    />
+                  </div>
+                  <div class="mb-3">
+                    <label class="form-label d-block">PIN behavior</label>
+                    <div class="form-check">
+                      <input class="form-check-input" type="radio" id="disableSimPinPermanent" value="permanent" x-model="simPinDisableMode">
+                      <label class="form-check-label" for="disableSimPinPermanent">
+                        Disable SIM PIN permanently
+                      </label>
+                    </div>
+                    <div class="form-check mt-1">
+                      <input class="form-check-input" type="radio" id="disableSimPinTemporary" value="temporary" x-model="simPinDisableMode">
+                      <label class="form-check-label" for="disableSimPinTemporary">
+                        Disable SIM PIN until reboot (SIM will require PIN again after restart)
+                      </label>
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    class="btn btn-primary w-100"
+                    :disabled="isSimUnlocking"
+                    @click="unlockSimPin()">
+                    <span x-show="!isSimUnlocking">Unlock SIM</span>
+                    <span x-show="isSimUnlocking">Unlocking...</span>
+                  </button>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- Replace the previous PIN persistence flow with two simpler choices: disable the SIM PIN permanently or disable it only until reboot, with the default set to permanent.
- Remove storing of the last successful PIN to avoid persisting sensitive data and to simplify the UX and code.
- Make it explicit in the UI when the temporary option is chosen that the SIM will require the PIN again after restart.

### Description
- Replaced the previous `Remember this PIN` / `Disable SIM PIN` controls with radio buttons bound to `simPinDisableMode` (default `permanent`) in `www/index.html`.
- Updated the unlock logic in `www/js/index-process.js` in `unlockSimPin()` to run `AT+CPIN`, verify with `AT+CPIN?`, and either call `AT+CLCK="SC",0,"<PIN>"` for permanent disable or skip persistence for the reboot-only path, and then call `fetchAllInfo()`.
- Removed the PIN persistence code and the `saveLastPin` function as well as the CGI endpoint `www/cgi-bin/save_lastpin`.
- Preserved existing AT command call patterns and status messaging while clarifying UI copy for the temporary-unlock case.

### Testing
- No automated tests were run as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69652c1b8dc08327adde3de71addb85a)