### PR TITLE
Keep SIM PIN form visible and preserve input

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -901,7 +901,11 @@
                     </tbody>
                   </table>
                 </div>
-                <div x-show="isSimPinRequired()" class="mt-3">
+                <div
+                  class="mt-3"
+                  :class="{ 'opacity-50 pointer-events-none': isSimPinSectionDisabled() }"
+                  :aria-disabled="isSimPinSectionDisabled()"
+                >
                   <hr class="my-3" />
                   <h6 class="fw-semibold">Unlock SIM PIN</h6>
                   <p class="text-muted small mb-3">Enter the SIM PIN to unlock the SIM. Choose whether to disable the PIN permanently or until reboot.</p>
@@ -915,6 +919,7 @@
                       inputmode="numeric"
                       class="form-control"
                       x-model="simPin"
+                      :disabled="isSimPinSectionDisabled()"
                       placeholder="Enter PIN"
                       autocomplete="off"
                     />
@@ -922,13 +927,13 @@
                   <div class="mb-3">
                     <label class="form-label d-block">PIN behavior</label>
                     <div class="form-check">
-                      <input class="form-check-input" type="radio" id="disableSimPinPermanent" value="permanent" x-model="simPinDisableMode">
+                      <input class="form-check-input" type="radio" id="disableSimPinPermanent" value="permanent" x-model="simPinDisableMode" :disabled="isSimPinSectionDisabled()">
                       <label class="form-check-label" for="disableSimPinPermanent">
                         Disable SIM PIN permanently
                       </label>
                     </div>
                     <div class="form-check mt-1">
-                      <input class="form-check-input" type="radio" id="disableSimPinTemporary" value="temporary" x-model="simPinDisableMode">
+                      <input class="form-check-input" type="radio" id="disableSimPinTemporary" value="temporary" x-model="simPinDisableMode" :disabled="isSimPinSectionDisabled()">
                       <label class="form-check-label" for="disableSimPinTemporary">
                         Disable SIM PIN until reboot (SIM will require PIN again after restart)
                       </label>
@@ -937,7 +942,7 @@
                   <button
                     type="button"
                     class="btn btn-primary w-100"
-                    :disabled="isSimUnlocking"
+                    :disabled="isSimUnlocking || isSimPinSectionDisabled()"
                     @click="unlockSimPin()">
                     <span x-show="!isSimUnlocking">Unlock SIM</span>
                     <span x-show="isSimUnlocking">Unlocking...</span>

--- a/www/js/index-process.js
+++ b/www/js/index-process.js
@@ -203,6 +203,8 @@ function processAllInfos() {
         refreshRate: this.refreshRate,
         newRefreshRate: this.newRefreshRate,
         intervalId: this.intervalId,
+        simPin: this.simPin,
+        simPinDisableMode: this.simPinDisableMode,
       };
 
       Object.assign(
@@ -2795,6 +2797,12 @@ function processAllInfos() {
   isSimPinRequired() {
     const status = String(this.simStatus || '').trim().toUpperCase();
     return status.includes('SIM PIN');
+  },
+
+  isSimPinSectionDisabled() {
+    const status = String(this.simStatus || '').trim().toUpperCase();
+    const simReady = status === 'ACTIVE' || status === 'READY';
+    return simReady && !this.isSimPinRequired();
   },
 
   async unlockSimPin() {


### PR DESCRIPTION
### Motivation
- The SIM PIN input was being cleared on periodic data refreshes, preventing quick entry within the required time window.
- The SIM PIN block was hidden when not required, but the UI should remain visible and only be disabled/greyed out when there is no PIN to enter and the SIM is ready.

### Description
- Preserve `simPin` and `simPinDisableMode` across data resets by adding them to the preserved state in `resetData()` in `www/js/index-process.js`.
- Add `isSimPinSectionDisabled()` helper to determine when the PIN section should be non-interactive based on `simStatus` in `www/js/index-process.js`.
- Always render the PIN UI block in `www/index.html` and apply a greyed-out/disabled state using `:class`, `:aria-disabled`, `:disabled` attributes and by combining with the existing `isSimUnlocking` button state.

### Testing
- Started a local static server with `python -m http.server 8000` to serve the app, which launched successfully.  
- Verified the page was reachable using `curl -I http://127.0.0.1:8000/index.html`, which returned HTTP 200 OK.  
- Ran a Playwright script to load the page and capture a screenshot, which produced a screenshot artifact but failed to find/click the modal trigger (selector count was 0) so interaction with the modal timed out (partial/failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69653f79a5d88327b03c00dfd5a07576)