### PR TITLE
Centralize UI version label

### DIFF
--- a/www/advanced.html
+++ b/www/advanced.html
@@ -64,6 +64,7 @@
     <script src="js/reboot-utils.js" defer></script>
     <script src="js/device-info.js"></script>
     <script src="js/dark-mode.js" defer></script>
+    <script src="js/app-version.js" defer></script>
   </head>
   <body data-require-auth="true">
     <main>
@@ -456,7 +457,7 @@
                 <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
                 <line x1="12" y1="17" x2="12.01" y2="17"/>
               </svg>
-              <span>Simple T99-RC06-Final</span>
+              <span data-app-version></span>
             </span>
           </div>
           <div class="col-md-6 text-center text-md-end">

--- a/www/credentials.html
+++ b/www/credentials.html
@@ -64,6 +64,7 @@
     <script src="js/reboot-utils.js" defer></script>
     <script src="js/device-info.js"></script>
     <script src="js/dark-mode.js" defer></script>
+    <script src="js/app-version.js" defer></script>
   </head>
   <body data-require-auth="true">
     <main>
@@ -387,7 +388,7 @@
                 <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
                 <line x1="12" y1="17" x2="12.01" y2="17"/>
               </svg>
-              <span>Simple T99-RC06-Final</span>
+              <span data-app-version></span>
             </span>
           </div>
           <div class="col-md-6 text-center text-md-end">

--- a/www/deviceinfo.html
+++ b/www/deviceinfo.html
@@ -63,6 +63,7 @@
     <script src="js/atcommand-utils.js"></script>
     <script src="js/reboot-utils.js" defer></script>
     <script src="js/dark-mode.js" defer></script>
+    <script src="js/app-version.js" defer></script>
   </head>
   <body data-require-auth="true">
     <main>
@@ -507,7 +508,7 @@
                 <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
                 <line x1="12" y1="17" x2="12.01" y2="17"/>
               </svg>
-              <span>Simple T99-RC06-Final</span>
+              <span data-app-version></span>
             </span>
           </div>
           <div class="col-md-6 text-center text-md-end">

--- a/www/esim.html
+++ b/www/esim.html
@@ -65,6 +65,7 @@
     <script src="js/reboot-utils.js" defer></script>
     <script src="js/device-info.js"></script>
     <script src="js/dark-mode.js" defer></script>
+    <script src="js/app-version.js" defer></script>
   </head>
   <body data-require-auth="true">
     <main>
@@ -842,7 +843,7 @@
                 <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
                 <line x1="12" y1="17" x2="12.01" y2="17"/>
               </svg>
-              <span>Simple T99-RC06-Final</span>
+              <span data-app-version></span>
             </span>
           </div>
           <div class="col-md-6 text-center text-md-end">

--- a/www/index.html
+++ b/www/index.html
@@ -66,6 +66,7 @@
     <!-- device-info.js no longer needed - all data is now in index-process.js -->
     <!-- <script src="js/device-info.js"></script> -->
     <script src="js/dark-mode.js" defer></script>
+    <script src="js/app-version.js" defer></script>
   </head>
   <body data-require-auth="true">
     <main x-data="processAllInfos()">
@@ -1719,7 +1720,7 @@
                 <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
                 <line x1="12" y1="17" x2="12.01" y2="17"/>
               </svg>
-              <span>Simple T99-RC06-Final</span>
+              <span data-app-version></span>
             </span>
           </div>
           <div class="col-md-6 text-center text-md-end">

--- a/www/js/app-version.js
+++ b/www/js/app-version.js
@@ -1,0 +1,15 @@
+(function() {
+  const APP_VERSION = "Simple T99-RC06-Final";
+
+  function applyVersion() {
+    document.querySelectorAll('[data-app-version]').forEach((el) => {
+      el.textContent = APP_VERSION;
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", applyVersion);
+  } else {
+    applyVersion();
+  }
+})();

--- a/www/monitor.html
+++ b/www/monitor.html
@@ -64,6 +64,7 @@
     <script src="js/reboot-utils.js" defer></script>
     <script src="js/device-info.js"></script>
     <script src="js/monitor.js"></script>
+    <script src="js/app-version.js" defer></script>
   </head>
   <body data-require-auth="true">
     <main>
@@ -326,7 +327,7 @@
                 <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
                 <line x1="12" y1="17" x2="12.01" y2="17"/>
               </svg>
-              <span>Simple T99-RC06-Final</span>
+              <span data-app-version></span>
             </span>
           </div>
           <div class="col-md-6 text-center text-md-end">

--- a/www/radio-settings.html
+++ b/www/radio-settings.html
@@ -67,6 +67,7 @@
     <script src="js/reboot-utils.js" defer></script>
     <script src="js/device-info.js"></script>
     <script src="js/dark-mode.js" defer></script>
+    <script src="js/app-version.js" defer></script>
   </head>
   <body data-require-auth="true">
     <main>
@@ -841,7 +842,7 @@
                 <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
                 <line x1="12" y1="17" x2="12.01" y2="17"/>
               </svg>
-              <span>Simple T99-RC06-Final</span>
+              <span data-app-version></span>
             </span>
           </div>
           <div class="col-md-6 text-center text-md-end">

--- a/www/settings.html
+++ b/www/settings.html
@@ -64,6 +64,7 @@
     <script src="js/reboot-utils.js" defer></script>
     <script src="js/device-info.js"></script>
     <script src="js/dark-mode.js" defer></script>
+    <script src="js/app-version.js" defer></script>
   </head>
   <body data-require-auth="true">
     <main>
@@ -980,7 +981,7 @@
                 <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
                 <line x1="12" y1="17" x2="12.01" y2="17"/>
               </svg>
-              <span>Simple T99-RC06-Final</span>
+              <span data-app-version></span>
             </span>
           </div>
           <div class="col-md-6 text-center text-md-end">

--- a/www/sms.html
+++ b/www/sms.html
@@ -65,7 +65,8 @@
   <script src="js/device-info.js"></script>
   <script src="js/dark-mode.js" defer></script>
   
-</head>
+    <script src="js/app-version.js" defer></script>
+  </head>
 
 <body data-require-auth="true">
   <main>
@@ -425,7 +426,7 @@
                 <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>
                 <line x1="12" y1="17" x2="12.01" y2="17"/>
               </svg>
-              <span>Simple T99-RC06-Final</span>
+              <span data-app-version></span>
             </span>
           </div>
           <div class="col-md-6 text-center text-md-end">


### PR DESCRIPTION
### Motivation
- Make the UI version label configurable from a single place so updating the version updates all pages consistently.
- Replace hardcoded footer version text with a reusable marker to avoid duplication and drift across pages.

### Description
- Add `www/js/app-version.js` which defines a single `APP_VERSION` constant and populates all elements matching `[data-app-version]` on DOM ready.
- Replace footer hardcoded `<span>Simple T99-RC06-Final</span>` with `<span data-app-version></span>` in multiple pages including `index.html`, `settings.html`, `monitor.html`, `sms.html`, `radio-settings.html`, `deviceinfo.html`, `advanced.html`, `esim.html`, and `credentials.html`.
- Insert `<script src="js/app-version.js" defer></script>` into the affected HTML files and commit the changes.

### Testing
- No automated test suite was run for this change.
- Verified presence of the new script and markers with `rg -n "app-version|data-app-version" www/*.html`, which reported expected matches.
- Inspected `www/js/app-version.js` with `nl` to confirm its content and completed a `git commit`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69708ee5f3408327a52e4cb8b987fa0f)