### PR TITLE
Document AT commands used by the GUI and required parsing data

### DIFF
--- a/necessary data.md
+++ b/necessary data.md
@@ -1,0 +1,81 @@
+# Necessary data fields for GUI parsing
+
+This list summarizes the **data points the frontend expects to parse** from AT command responses.
+It is grouped by screen/module so you can attach example payloads later.
+
+## Dashboard / status (index page)
+- SIM status/state (READY, PIN, PUK) from `+CPIN:`
+- Active SIM slot (1/2/unknown) from `^SWITCH_SLOT?`
+- Temperatures from `^TEMP?`:
+  - TSENS (baseband temp)
+  - PA temperature
+  - Skin sensor temperature
+- Network provider/operator name from `+COPS:`
+- MCC/MNC (combined `mcc:`/`mnc:`) from `^DEBUG?`
+- APN name from `+CGCONTRDP:`
+- IP addresses from `+CGCONTRDP:`
+  - IPv4
+  - IPv6
+- Network mode / RAT (`RAT:`) from `^DEBUG?`
+- LTE bands + NR bands from `^DEBUG?`
+- Bandwidths (LTE + NR) from `^DEBUG?`
+- Channel numbers (LTE `channel:` and NR `nr_channel:`)
+- PCI values (LTE `pci:` and NR `nr_pci:`)
+- Cell IDs (LTE `lte_cell_id`, NR `nr_cell_id`) and TACs
+- Signal metrics:
+  - RSRP/RSRQ/RSSI/SINR/SNR for LTE/NR
+  - CSQ (RSSI/BER) fallback
+- Antenna data:
+  - LTE/NR per-antenna RSRP values
+  - RX diversity bitmask
+- SIM identifiers and device identity (from the combined command set):
+  - IMSI (`AT+CIMI`)
+  - ICCID (`AT+ICCID`)
+  - Phone number (`+CNUM`)
+  - IMEI (`AT+CGSN`)
+  - Manufacturer (`AT+CGMI`)
+  - Model (`AT+CGMM`)
+  - Firmware version (`^VERSION?`)
+
+## Device info page
+- Manufacturer (`AT+CGMI`)
+- Model (`AT+CGMM`)
+- Firmware version (`^VERSION?`)
+- IMSI (`AT+CIMI`)
+- ICCID (`AT+ICCID`)
+- IMEI (`AT+CGSN`)
+- Phone number (`+CNUM`)
+- WWAN IPv4/IPv6 (`+CGCONTRDP:`)
+- LAN IP (from `/cgi-bin/get_lanip` response)
+
+## Radio settings
+- APN profiles (CID, PDP type, APN) from `+CGDCONT:`
+- Active APN + IP addresses from `+CGCONTRDP:`
+- Current network mode (parsed from `^SLMODE?`)
+- SIM slot selection (from `^SWITCH_SLOT?`)
+- Band preferences + lock state from `^BAND_PREF_EXT?`
+- CA info (from `^CA_INFO?`, if available)
+- LTE lock state (from `^LTE_LOCK?`)
+- NR5G lock state (from `^NR5G_LOCK?`)
+- NR5G mode (from `^NR5G_MODE?`)
+
+## SMS
+- Storage status (memory type, used slots, total slots) from `+CPMS:`
+- Service center number from `+CSCA:`
+- Message list from `+CMGL:`
+  - Index
+  - Status
+  - Sender number
+  - Timestamp (date + time)
+  - Message content (UCS-2 decoded)
+  - Multipart metadata (reference, total parts, part index when present)
+
+## SIM unlock / PIN control
+- PIN status (`+CPIN:`)
+- PIN unlock results (success/error)
+- SIM PIN lock toggle response (`+CLCK:`)
+
+## Factory reset + maintenance flows
+- Band/cell lock clear success (OK/ERROR responses from `AT^BAND_PREF_EXT`,
+  `AT^LTE_LOCK`, `AT^NR5G_LOCK`)
+- Mode resets and reboot responses (`AT^SLMODE=1,0`, `AT^NR5G_MODE=0`, `AT+CFUN=1,1`)

--- a/needed command.md
+++ b/needed command.md
@@ -1,0 +1,76 @@
+# Needed AT commands for the GUI (from JS + frontend usage)
+
+This list is based on the commands referenced directly in the JavaScript UI logic and CGI helpers.
+It groups commands by feature so you can later add parsing examples.
+
+## Dashboard / home status (index page)
+- SIM state: `AT+CPIN?`
+- Temperature + SIM slot: `AT^TEMP?`, `AT^SWITCH_SLOT?`
+- Full status bundle (single multi-command request):
+  - `AT^TEMP?;^SWITCH_SLOT?;+CGPIAF=1,1,1,1;^DEBUG?;+CPIN?;+CGCONTRDP=1;$QCSIMSTAT?;+CSQ;+COPS?;+CIMI;+ICCID;+CNUM;+CSCS="GSM";+CGMI;+CGMM;^VERSION?;+CGSN`
+- SIM unlock: `AT+CPIN="<pin>"`
+- Disable SIM PIN: `AT+CLCK="SC",0,"<pin>"`
+- Modem NV tuning (used for saving/clearing custom data): `AT^NV=550,0`, `AT^NV=550,<byte_count>,"<hex_payload>"`
+
+## Device info page
+- Device identification: `AT+CGMI`, `AT+CGMM`, `AT^VERSION?`, `AT+CGSN`
+- SIM/phone info: `AT+CIMI`, `AT+ICCID`, `AT+CNUM`
+- Data connection: `AT+CGCONTRDP=1`
+
+## Radio settings / cellular configuration
+- APN profiles: `AT+CGDCONT?`, `AT+CGDCONT=<cid>`, `AT+CGDCONT=1,"<type>","<apn>"`
+- APN info / PDP: `AT+CGCONTRDP=1`
+- Band preferences: `AT^BAND_PREF_EXT?`, `AT^BAND_PREF_EXT=<tech>,2,<bands>`, `AT^BAND_PREF_EXT` (clear)
+- CA + serving cell info: `AT^CA_INFO?`, `AT^DEBUG?`
+- SIM slot + mode: `AT^SWITCH_SLOT?`, `AT^SWITCH_SLOT=<slot>`, `AT^SLMODE?`, `AT^SLMODE=1,<mode>`
+- SIM presence: `AT+CPIN?`
+- Radio power: `AT+CFUN=0`, `AT+CFUN=1`, `AT+CFUN=1,1`
+- LTE/NR locks: `AT^LTE_LOCK?`, `AT^LTE_LOCK=<pairs>`, `AT^LTE_LOCK` (clear)
+- 5G locks: `AT^NR5G_LOCK?`, `AT^NR5G_LOCK=<band>,<scs>,<earfcn>,<pci>`, `AT^NR5G_LOCK` (clear)
+- 5G mode: `AT^NR5G_MODE?`, `AT^NR5G_MODE=<mode>`, `AT^NR5G_MODE=0` (reset)
+
+## SMS (frontend + send SMS CGI)
+- Storage selection: `AT+CPMS?`, `AT+CPMS="<mem>","<mem>","<mem>"`
+- SMS setup and list: `AT+CSMS=1`, `AT+CSDH=0`, `AT+CNMI=2,1,0,0,0`, `AT+CMGF=1`, `AT+CSCA?`, `AT+CSMP=17,167,0,8`, `AT+CMGL="ALL"`
+- Delete SMS: `AT+CMGD=<index>`, `AT+CMGD=,4`
+- Send SMS (CGI): `AT+CSCS="UCS2"`, `AT+CMGS="<number>"`
+
+## Factory reset (CGI helper)
+- Clear band and cell locks: `AT^BAND_PREF_EXT`, `AT^LTE_LOCK`, `AT^NR5G_LOCK`
+- Reset mode defaults: `AT^SLMODE=1,0`, `AT^NR5G_MODE=0`
+
+---
+
+# AT commands in the Quectel manual that are relevant to reading GUI data
+
+These commands appear in the Quectel AT command manual PDF and can provide read-only data
+that aligns with the GUI fields (device info, SIM state, network status, SMS):
+
+## Device / SIM / network status
+- `AT+CPIN?` (SIM state)
+- `AT+CSQ` (signal strength)
+- `AT+COPS?` (operator selection / name)
+- `AT+CIMI` (IMSI)
+- `AT+CNUM` (phone number)
+- `AT+CGMI` (manufacturer)
+- `AT+CGMM` (model)
+- `AT+CGSN` (IMEI)
+- `AT+CGDCONT?` (PDP context / APN profiles)
+- `AT+CFUN?` (functionality status)
+
+## SMS readback
+- `AT+CPMS?` (message storage info)
+- `AT+CSMS` (SMS service support)
+- `AT+CSDH` (show SMS headers)
+- `AT+CNMI` (new message indications)
+- `AT+CMGF?` (text/PDU mode)
+- `AT+CSCA?` (service center number)
+- `AT+CSMP` (SMS text mode parameters)
+- `AT+CMGL` (list messages)
+- `AT+CMGD` (delete messages)
+- `AT+CMGS` (send message)
+- `AT+CLCK` (SIM lock status/operations)
+
+> Note: The GUI also relies on vendor-specific `AT^...` commands (e.g. `AT^DEBUG?`,
+> `AT^TEMP?`, `AT^BAND_PREF_EXT?`). Those do not appear in this PDF text extraction,
+> so they may be documented elsewhere or in a different Quectel-specific manual.


### PR DESCRIPTION
### Motivation
- Provide a clear inventory of AT commands the frontend and CGI scripts rely on so the fork can be adapted to other Quectel modems.
- Collect the exact data fields the UI expects to parse so example payloads and parsers can be added later.

### Description
- Add `needed command.md` containing grouped AT commands referenced in JS and CGI code (dashboard, device info, radio settings, SMS, factory reset).
- Add `necessary data.md` listing the data points the frontend parses (SIM state, temperatures, APN/IP, bands, signal metrics, identifiers, SMS fields, etc.).
- Contents were produced by scanning the `www/js` frontend files, CGI helpers and the Quectel AT commands PDF to correlate GUI needs with documented commands.

### Testing
- No automated tests were run because these are documentation-only additions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d2bcbf0c8327a4b5dbe63770ee3a)