### PR TITLE
Add runnable Quectel AT command inventory and GUI data-field spec

### DIFF
--- a/necessary data.md
+++ b/necessary data.md
@@ -1,0 +1,84 @@
+# Necessary data fields for GUI parsing
+
+This list names the **exact data fields** the frontend currently parses.
+Use it to attach sample AT responses for each field when adapting to other
+Quectel modems.
+
+---
+
+## Dashboard / status (index page)
+- SIM status/state (`+CPIN:` → READY / SIM PIN / SIM PUK)
+- Active SIM slot (from `^SWITCH_SLOT?` → slot ENABLE line)
+- Temperatures (from `^TEMP?`):
+  - TSENS
+  - PA temperature
+  - Skin sensor temperature
+- Network provider name (from `+COPS:`)
+- MCC/MNC (from `mcc:` / `mnc:` in `^DEBUG?`)
+- APN name (from `+CGCONTRDP:`)
+- IP addresses (from `+CGCONTRDP:`): IPv4 + IPv6
+- RAT / network mode (from `RAT:` in `^DEBUG?`)
+- LTE bands (from `lte_band:`)
+- NR bands (from `nr_band:`)
+- Bandwidths (from `lte_band_width:` / `nr_band_width:`)
+- Channel numbers (from `channel:` and `nr_channel:`)
+- PCI values (from `pci:` and `nr_pci:`)
+- Cell IDs (from `lte_cell_id`, `nr_cell_id`)
+- TACs (from `lte_tac`, `nr_tac`)
+- Signal metrics (from `^DEBUG?` + `+CSQ` fallback):
+  - RSRP / RSRQ / RSSI / SNR/SINR
+- Antenna data (from `^DEBUG?`):
+  - Per-antenna RSRP values
+  - RX diversity bitmask
+- SIM + device identifiers (from the combined bundle):
+  - IMSI (`AT+CIMI`)
+  - ICCID (`AT+ICCID`)
+  - Phone number (`+CNUM`)
+  - IMEI (`AT+CGSN`)
+  - Manufacturer (`AT+CGMI`)
+  - Model (`AT+CGMM`)
+  - Firmware version (`^VERSION?`)
+
+## Device info page
+- Manufacturer (`AT+CGMI`)
+- Model (`AT+CGMM`)
+- Firmware version (`^VERSION?`)
+- IMSI (`AT+CIMI`)
+- ICCID (`AT+ICCID`)
+- IMEI (`AT+CGSN`)
+- Phone number (`+CNUM`)
+- WWAN IPv4/IPv6 (from `+CGCONTRDP:`)
+- LAN IP (from `/cgi-bin/get_lanip` response)
+
+## Radio settings
+- APN profiles (from `+CGDCONT:`): CID, PDP type, APN
+- Active APN + IP addresses (from `+CGCONTRDP:`)
+- Network mode (parsed from `^SLMODE?`)
+- SIM slot selection (from `^SWITCH_SLOT?`)
+- Band preferences + lock state (from `^BAND_PREF_EXT?`)
+- CA info (from `^CA_INFO?`, if available)
+- LTE lock state (from `^LTE_LOCK?`)
+- NR5G lock state (from `^NR5G_LOCK?`)
+- NR5G mode (from `^NR5G_MODE?`)
+
+## SMS
+- Storage status (from `+CPMS:`): memory type, used slots, total slots
+- Service center number (from `+CSCA:`)
+- Message list (from `+CMGL:`):
+  - Index
+  - Status
+  - Sender number
+  - Timestamp
+  - Content (UCS-2 decoded)
+  - Multipart metadata (reference, total parts, part index when present)
+
+## SIM unlock / PIN control
+- PIN status (`+CPIN:`)
+- PIN unlock result (OK/ERROR)
+- SIM PIN lock toggle response (`+CLCK:`)
+
+## Factory reset + maintenance flows
+- Band/cell lock clear success (OK/ERROR from `AT^BAND_PREF_EXT`,
+  `AT^LTE_LOCK`, `AT^NR5G_LOCK`)
+- Mode resets and reboot responses (`AT^SLMODE=1,0`, `AT^NR5G_MODE=0`,
+  `AT+CFUN=1,1`)

--- a/needed command.md
+++ b/needed command.md
@@ -1,0 +1,184 @@
+# Needed Quectel AT commands for GUI data collection
+
+This file is the **actionable command list** you can run against a Quectel modem
+to collect the data the GUI expects. Each section maps directly to fields the
+frontend parses, so you can later add example payloads and parsing notes.
+
+> Note: The GUI uses both standard `AT+...` commands and vendor-specific
+> `AT^...` commands. The Quectel PDF bundled here contains mostly `AT+...`.
+> The `AT^...` commands come from existing modem logic/firmware docs and are
+> required by the current frontend.
+
+---
+
+## 1) Core status (dashboard)
+Run this full bundle when the SIM is ready (current GUI behavior):
+
+```
+AT^TEMP?;^SWITCH_SLOT?;+CGPIAF=1,1,1,1;^DEBUG?;+CPIN?;+CGCONTRDP=1;$QCSIMSTAT?;+CSQ;+COPS?;+CIMI;+ICCID;+CNUM;+CSCS="GSM";+CGMI;+CGMM;^VERSION?;+CGSN
+```
+
+If the SIM is **not ready**, the GUI only runs the basic read:
+
+```
+AT^TEMP?;^SWITCH_SLOT?
+```
+
+### Individual commands (core status)
+- `AT+CPIN?` (SIM state)
+- `AT^TEMP?` (temperatures)
+- `AT^SWITCH_SLOT?` (active SIM slot)
+- `AT+CGPIAF=1,1,1,1` (enable numeric format for PDP address)
+- `AT^DEBUG?` (serving cell + RF metrics)
+- `AT+CGCONTRDP=1` (APN + IP addresses)
+- `AT$QCSIMSTAT?` (SIM status detail)
+- `AT+CSQ` (signal strength fallback)
+- `AT+COPS?` (operator name)
+- `AT+CIMI` (IMSI)
+- `AT+ICCID` (ICCID)
+- `AT+CNUM` (phone number)
+- `AT+CSCS="GSM"` (character set for phone number parsing)
+- `AT+CGMI` (manufacturer)
+- `AT+CGMM` (model)
+- `AT^VERSION?` (firmware version)
+- `AT+CGSN` (IMEI)
+
+## 2) Device info page
+Run this bundle for the device info modal:
+
+```
+AT+CGMI;+CGMM;^VERSION?;+CIMI;+ICCID;+CGSN;+CNUM;+CGCONTRDP=1
+```
+
+## 3) Radio settings / cellular configuration
+### Read current configuration
+```
+AT^SWITCH_SLOT?;^SLMODE?
+AT+CPIN?
+AT+CGCONTRDP=1;+CGDCONT?;^BAND_PREF_EXT?;^CA_INFO?;^SLMODE?;^LTE_LOCK?;^NR5G_LOCK?
+AT^NR5G_MODE?
+```
+
+### APN management
+```
+AT+CGDCONT?
+AT+CGDCONT=<cid>
+AT+CGDCONT=1,"<type>","<apn>"
+```
+
+### Band preferences / lock
+```
+AT^BAND_PREF_EXT?
+AT^BAND_PREF_EXT=<tech>,2,<bands>
+AT^BAND_PREF_EXT        (clear)
+```
+
+### SIM slot / mode management
+```
+AT^SWITCH_SLOT=<slot>
+AT^SLMODE=1,<mode>
+```
+
+### Radio power & reboot
+```
+AT+CFUN=0
+AT+CFUN=1
+AT+CFUN=1,1
+```
+
+### Cell locks
+```
+AT^LTE_LOCK?
+AT^LTE_LOCK=<pairs>
+AT^LTE_LOCK             (clear)
+
+AT^NR5G_LOCK?
+AT^NR5G_LOCK=<band>,<scs>,<earfcn>,<pci>
+AT^NR5G_LOCK            (clear)
+
+AT^NR5G_MODE?
+AT^NR5G_MODE=<mode>
+AT^NR5G_MODE=0          (reset)
+```
+
+## 4) SMS (frontend + send SMS CGI)
+### Storage selection
+```
+AT+CPMS?
+AT+CPMS="<mem>","<mem>","<mem>"
+```
+
+### SMS read
+```
+AT+CSMS=1
+AT+CSDH=0
+AT+CNMI=2,1,0,0,0
+AT+CMGF=1
+AT+CSCA?
+AT+CSMP=17,167,0,8
+AT+CMGL="ALL"
+```
+
+### SMS delete
+```
+AT+CMGD=<index>
+AT+CMGD=,4
+```
+
+### SMS send (CGI)
+```
+AT+CSCS="UCS2"
+AT+CMGS="<number>"
+```
+
+## 5) SIM unlock / PIN control
+```
+AT+CPIN="<pin>"
+AT+CLCK="SC",0,"<pin>"
+```
+
+## 6) Factory reset (CGI helper)
+```
+AT^BAND_PREF_EXT
+AT^LTE_LOCK
+AT^NR5G_LOCK
+AT^SLMODE=1,0
+AT^NR5G_MODE=0
+```
+
+---
+
+# Commands found in the bundled Quectel PDF that map to GUI data
+
+The following **standard** commands are present in the PDF and correspond to
+GUI readback needs. These are listed separately so you can confirm availability
+on other Quectel models:
+
+## Device / SIM / network status
+- `AT+CPIN?`
+- `AT+CSQ`
+- `AT+COPS?`
+- `AT+CIMI`
+- `AT+CNUM`
+- `AT+CGMI`
+- `AT+CGMM`
+- `AT+CGSN`
+- `AT+CGDCONT?`
+- `AT+CFUN?`
+
+## SMS
+- `AT+CPMS?`
+- `AT+CSMS`
+- `AT+CSDH`
+- `AT+CNMI`
+- `AT+CMGF?`
+- `AT+CSCA?`
+- `AT+CSMP`
+- `AT+CMGL`
+- `AT+CMGD`
+- `AT+CMGS`
+- `AT+CLCK`
+
+> Vendor-specific commands used by the GUI (`AT^TEMP?`, `AT^DEBUG?`,
+> `AT^BAND_PREF_EXT?`, etc.) are not listed in the PDF text extraction and may
+> require a Quectel private/extended command reference.


### PR DESCRIPTION
### Motivation
- Provide an actionable, runnable list of Quectel `AT` commands that map directly to the GUI data the frontend expects. 
- Make it easier to implement parsers by listing bundled command sets for dashboard, device info, radio, SMS, SIM control and factory-reset flows. 
- Clarify which commands are vendor-specific and may be missing from the public Quectel PDF so implementers know to look for private/extended references.

### Description
- Add `needed command.md` containing grouped, runnable command bundles and the individual `AT`/`AT^` commands used by the GUI for core status, device info, radio settings, SMS, SIM PIN and factory-reset helpers. 
- Add `necessary data.md` enumerating the exact data fields the frontend parses (SIM state, temperatures, APN/IP, bands, signal metrics, identifiers, SMS fields, lock states, etc.). 
- Explicitly call out that many vendor-specific `AT^...` commands used by the GUI are not present in the bundled public PDF extraction and may require a Quectel private/extended command reference. 
- Commit message: `Clarify Quectel command list and data fields`.

### Testing
- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981d2bcbf0c8327a4b5dbe63770ee3a)