### PR TITLE
Add Tailscale management block in Advanced > One Click Utilities

### DIFF
--- a/www/advanced.html
+++ b/www/advanced.html
@@ -332,6 +332,77 @@
                             </button>
                           </td>
                         </tr>
+                        <tr>
+                          <th scope="row">
+                            <div class="fw-semibold">Tailscale</div>
+                            <div class="small text-muted" x-text="tailscaleStatusSummary"></div>
+                          </th>
+                          <td class="text-end">
+                            <div class="d-inline-flex flex-wrap gap-2 justify-content-end">
+                              <button
+                                type="button"
+                                class="btn btn-outline-primary btn-sm"
+                                @click="fetchTailscaleStatus()"
+                                :disabled="tailscaleBusy"
+                              >
+                                Refresh
+                              </button>
+                              <button
+                                type="button"
+                                class="btn btn-primary btn-sm"
+                                @click="installTailscale()"
+                                :disabled="tailscaleBusy || tailscaleInstalled"
+                              >
+                                Install
+                              </button>
+                              <button
+                                type="button"
+                                class="btn btn-outline-danger btn-sm"
+                                @click="removeTailscale()"
+                                :disabled="tailscaleBusy || !tailscaleInstalled"
+                              >
+                                Remove
+                              </button>
+                            </div>
+                            <div class="input-group input-group-sm mt-2" x-show="tailscaleInstalled && !tailscaleConnected" x-cloak>
+                              <input
+                                type="text"
+                                class="form-control"
+                                placeholder="tskey-auth-..."
+                                x-model="tailscaleAuthKey"
+                                :disabled="tailscaleBusy"
+                              />
+                              <button
+                                class="btn btn-success"
+                                type="button"
+                                @click="connectTailscale()"
+                                :disabled="tailscaleBusy || !tailscaleAuthKey"
+                              >
+                                Login
+                              </button>
+                            </div>
+                            <div class="d-inline-flex flex-wrap gap-2 justify-content-end mt-2" x-show="tailscaleInstalled" x-cloak>
+                              <button
+                                type="button"
+                                class="btn btn-success btn-sm"
+                                @click="upTailscale()"
+                                :disabled="tailscaleBusy || tailscaleConnected"
+                              >
+                                Start
+                              </button>
+                              <button
+                                type="button"
+                                class="btn btn-outline-secondary btn-sm"
+                                @click="downTailscale()"
+                                :disabled="tailscaleBusy || !tailscaleConnected"
+                              >
+                                Stop
+                              </button>
+                            </div>
+                            <div class="small text-muted mt-2 text-start" x-show="tailscaleStatusLine" x-text="tailscaleStatusLine"></div>
+                            <div class="small text-danger mt-1 text-start" x-show="tailscaleError" x-text="tailscaleError"></div>
+                          </td>
+                        </tr>
 
                       </tbody>
                     </table>

--- a/www/cgi-bin/tailscale
+++ b/www/cgi-bin/tailscale
@@ -1,0 +1,143 @@
+#!/bin/bash
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/session_utils.sh"
+
+if ! session_load; then
+    send_json_response 401 '{"status":"error","message":"Authentication required"}'
+    exit 0
+fi
+
+if [ "$SESSION_ROLE" != "admin" ]; then
+    send_json_response 403 '{"status":"error","message":"Administrator access required"}'
+    exit 0
+fi
+
+TAILSCALE_BIN="${SIMPLEADMIN_TAILSCALE_BIN:-tailscale}"
+HELPER_SCRIPT="${SIMPLEADMIN_TAILSCALE_HELPER:-/usr/bin/tailscale-helper}"
+ACTION="${QUERY_STRING:-}"
+ACTION="${ACTION#action=}"
+AUTHKEY=""
+
+if printf '%s' "${QUERY_STRING:-}" | grep -q '&authkey='; then
+    AUTHKEY="$(printf '%s' "$QUERY_STRING" | sed -n 's/.*[?&]authkey=\([^&]*\).*/\1/p' | sed 's/%20/ /g; s/%2B/+/g; s/%2F/\//g; s/%3D/=/' )"
+fi
+
+json_bool() {
+    if [ "$1" = "true" ]; then
+        printf 'true'
+    else
+        printf 'false'
+    fi
+}
+
+is_installed() {
+    if command -v "$TAILSCALE_BIN" >/dev/null 2>&1; then
+        printf 'true'
+    else
+        printf 'false'
+    fi
+}
+
+is_connected() {
+    if command -v "$TAILSCALE_BIN" >/dev/null 2>&1 && "$TAILSCALE_BIN" status >/dev/null 2>&1; then
+        printf 'true'
+    else
+        printf 'false'
+    fi
+}
+
+status_text() {
+    if ! command -v "$TAILSCALE_BIN" >/dev/null 2>&1; then
+        printf 'Not installed'
+        return
+    fi
+
+    if "$TAILSCALE_BIN" status >/dev/null 2>&1; then
+        local line
+        line="$($TAILSCALE_BIN status 2>/dev/null | head -n1 || true)"
+        if [ -n "$line" ]; then
+            printf '%s' "$line"
+        else
+            printf 'Connected'
+        fi
+    else
+        printf 'Installed but not connected'
+    fi
+}
+
+respond_status() {
+    local installed connected line
+    installed="$(is_installed)"
+    connected="$(is_connected)"
+    line="$(status_text)"
+    line="$(json_escape "$line")"
+
+    send_json_response 200 "{\"status\":\"ok\",\"installed\":$(json_bool "$installed"),\"connected\":$(json_bool "$connected"),\"statusLine\":\"$line\"}"
+}
+
+run_helper() {
+    local op="$1"
+    if [ ! -x "$HELPER_SCRIPT" ]; then
+        send_json_response 404 '{"status":"error","message":"Tailscale helper script not found"}'
+        exit 0
+    fi
+
+    if "$HELPER_SCRIPT" "$op" >/tmp/simpleadmin-tailscale-helper.log 2>&1; then
+        send_json_response 200 "{\"status\":\"ok\",\"message\":\"Helper executed: $op\"}"
+    else
+        local out
+        out="$(tail -n 20 /tmp/simpleadmin-tailscale-helper.log | tr '\n' ' ' | sed 's/  */ /g')"
+        out="$(json_escape "$out")"
+        send_json_response 500 "{\"status\":\"error\",\"message\":\"$out\"}"
+    fi
+}
+
+run_tailscale() {
+    if ! command -v "$TAILSCALE_BIN" >/dev/null 2>&1; then
+        send_json_response 404 '{"status":"error","message":"Tailscale is not installed"}'
+        exit 0
+    fi
+
+    local cmd="$1"
+    shift
+
+    if "$TAILSCALE_BIN" "$cmd" "$@" >/tmp/simpleadmin-tailscale.log 2>&1; then
+        send_json_response 200 "{\"status\":\"ok\",\"message\":\"Tailscale $cmd successful\"}"
+    else
+        local out
+        out="$(tail -n 20 /tmp/simpleadmin-tailscale.log | tr '\n' ' ' | sed 's/  */ /g')"
+        out="$(json_escape "$out")"
+        send_json_response 500 "{\"status\":\"error\",\"message\":\"$out\"}"
+    fi
+}
+
+case "$ACTION" in
+    status|"")
+        respond_status
+        ;;
+    install)
+        run_helper install
+        ;;
+    remove)
+        run_helper remove
+        ;;
+    up)
+        run_tailscale up
+        ;;
+    down)
+        run_tailscale down
+        ;;
+    login)
+        if [ -z "$AUTHKEY" ]; then
+            send_json_response 400 '{"status":"error","message":"Missing authkey"}'
+            exit 0
+        fi
+        run_tailscale up --authkey "$AUTHKEY"
+        ;;
+    *)
+        send_json_response 400 '{"status":"error","message":"Invalid action"}'
+        ;;
+esac

--- a/www/js/advanced.js
+++ b/www/js/advanced.js
@@ -70,6 +70,114 @@ return {
     isFactoryResetting: false,
     // Factory reset countdown timer value
     resetCountdown: 60,
+    // Tailscale section state
+    tailscaleBusy: false,
+    tailscaleInstalled: false,
+    tailscaleConnected: false,
+    tailscaleStatusLine: "",
+    tailscaleStatusSummary: "Checking status...",
+    tailscaleAuthKey: "",
+    tailscaleError: "",
+
+    async tailscaleRequest(action, extraParams = {}) {
+      const params = new URLSearchParams({ action, ...extraParams });
+      const response = await fetch(`/cgi-bin/tailscale?${params.toString()}`);
+      const data = await response.json();
+      if (!response.ok || data.status !== "ok") {
+        throw new Error(data.message || `Request failed (${response.status})`);
+      }
+      return data;
+    },
+
+    async fetchTailscaleStatus() {
+      this.tailscaleBusy = true;
+      this.tailscaleError = "";
+      try {
+        const data = await this.tailscaleRequest("status");
+        this.tailscaleInstalled = Boolean(data.installed);
+        this.tailscaleConnected = Boolean(data.connected);
+        this.tailscaleStatusLine = data.statusLine || "";
+
+        if (!this.tailscaleInstalled) {
+          this.tailscaleStatusSummary = "Not installed";
+        } else if (this.tailscaleConnected) {
+          this.tailscaleStatusSummary = "Installed • Connected";
+        } else {
+          this.tailscaleStatusSummary = "Installed • Not connected";
+        }
+      } catch (error) {
+        this.tailscaleError = error.message || "Unable to read Tailscale status";
+        this.tailscaleStatusSummary = "Status unavailable";
+      } finally {
+        this.tailscaleBusy = false;
+      }
+    },
+
+    async installTailscale() {
+      this.tailscaleBusy = true;
+      this.tailscaleError = "";
+      try {
+        await this.tailscaleRequest("install");
+      } catch (error) {
+        this.tailscaleError = error.message || "Install failed";
+      } finally {
+        await this.fetchTailscaleStatus();
+      }
+    },
+
+    async removeTailscale() {
+      this.tailscaleBusy = true;
+      this.tailscaleError = "";
+      try {
+        await this.tailscaleRequest("remove");
+        this.tailscaleAuthKey = "";
+      } catch (error) {
+        this.tailscaleError = error.message || "Remove failed";
+      } finally {
+        await this.fetchTailscaleStatus();
+      }
+    },
+
+    async connectTailscale() {
+      if (!this.tailscaleAuthKey) {
+        this.tailscaleError = "Auth key is required";
+        return;
+      }
+
+      this.tailscaleBusy = true;
+      this.tailscaleError = "";
+      try {
+        await this.tailscaleRequest("login", { authkey: this.tailscaleAuthKey });
+      } catch (error) {
+        this.tailscaleError = error.message || "Login failed";
+      } finally {
+        await this.fetchTailscaleStatus();
+      }
+    },
+
+    async upTailscale() {
+      this.tailscaleBusy = true;
+      this.tailscaleError = "";
+      try {
+        await this.tailscaleRequest("up");
+      } catch (error) {
+        this.tailscaleError = error.message || "Unable to start Tailscale";
+      } finally {
+        await this.fetchTailscaleStatus();
+      }
+    },
+
+    async downTailscale() {
+      this.tailscaleBusy = true;
+      this.tailscaleError = "";
+      try {
+        await this.tailscaleRequest("down");
+      } catch (error) {
+        this.tailscaleError = error.message || "Unable to stop Tailscale";
+      } finally {
+        await this.fetchTailscaleStatus();
+      }
+    },
 
     /**
      * Closes the reboot confirmation modal.
@@ -374,6 +482,7 @@ return {
     init() {
     //this.fetchCurrentSettings();
     this.fetchTTL();
+    this.fetchTailscaleStatus();
     },
 };
 }


### PR DESCRIPTION
### Motivation
- Provide integrated Tailscale controls in the modem web UI under `Advanced > One Click Utilities` so administrators can check status, install/remove, start/stop, and authenticate the Tailscale daemon from the GUI while keeping the existing UI style.
- Use a helper script for install/remove operations and ensure admin-only access via existing session utilities.

### Description
- Added a new Tailscale row to `www/advanced.html` that displays a concise status summary and provides buttons for Refresh, Install, Remove, Login (via Auth Key), Start and Stop, plus inline status/error text, keeping the same button styles used elsewhere.
- Extended the Alpine.js `simpleSettings()` component in `www/js/advanced.js` with Tailscale state variables and async methods: `tailscaleRequest`, `fetchTailscaleStatus`, `installTailscale`, `removeTailscale`, `connectTailscale`, `upTailscale`, and `downTailscale`, and call `fetchTailscaleStatus()` during `init()`.
- Added a new CGI endpoint `www/cgi-bin/tailscale` which enforces session/auth and admin role, supports actions `status`, `install`, `remove`, `up`, `down`, and `login`, queries the `tailscale` binary when present, and delegates install/remove to a helper script (default `/usr/bin/tailscale-helper`), returning JSON responses expected by the frontend.
- Kept UI/behavior consistent with existing patterns (busy flags, inline messages, admin checks, and use of `session_utils.sh`).

### Testing
- Ran shell syntax check `bash -n www/cgi-bin/tailscale` which completed successfully.
- Validated the modified frontend JS by evaluating `node -e "new Function(require('fs').readFileSync('www/js/advanced.js','utf8'))"` which succeeded without syntax errors.
- Launched a local HTTP server and captured a Playwright screenshot of `www/advanced.html` to visually verify the new Tailscale block, which succeeded and produced an artifact screenshot.
- No automated unit tests were added; all changes were smoke-tested via the checks above and a visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6abf698e883278d58924481cb4f5c)